### PR TITLE
Add Namespace Validator object

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--format documentation

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    kube-dsl (0.1.0)
+    kube-dsl (0.2.0)
       dry-inflector (~> 0.2)
 
 GEM

--- a/lib/kube-dsl.rb
+++ b/lib/kube-dsl.rb
@@ -15,6 +15,7 @@ module KubeDSL
   autoload :ResourceMeta,         'kube-dsl/resource_meta'
   autoload :StringHelpers,        'kube-dsl/string_helpers'
   autoload :ValueFields,          'kube-dsl/value_fields'
+  autoload :Validator,            'kube-dsl/validator'
 
   extend Entrypoint
 end

--- a/lib/kube-dsl/dsl_object.rb
+++ b/lib/kube-dsl/dsl_object.rb
@@ -1,6 +1,7 @@
 module KubeDSL
   class DSLObject
     extend ::KubeDSL::ValueFields
+    include ::KubeDSL::Validator
 
     def initialize(&block)
       instance_eval(&block) if block

--- a/lib/kube-dsl/validator.rb
+++ b/lib/kube-dsl/validator.rb
@@ -1,0 +1,9 @@
+require 'pry'
+
+module KubeDSL
+  module Validator
+    def validate!
+      binding.pry
+    end
+  end
+end

--- a/lib/spec/kube-dsl/dsl/v1/namespace_spec.rb
+++ b/lib/spec/kube-dsl/dsl/v1/namespace_spec.rb
@@ -1,0 +1,19 @@
+require './lib/spec/spec_helper'
+
+describe KubeDSL::DSL::V1::Namespace do
+  subject(:object) { described_class.new }
+
+  describe '#validate!' do
+    context 'when metadata is an object' do
+      specify do
+        expect(object.validate!).to be_truthy
+      end
+    end
+
+    context 'when metadata is not an object' do
+      specify do
+        expect(object.validate!).to be_falsey
+      end
+    end
+  end
+end

--- a/lib/spec/spec_helper.rb
+++ b/lib/spec/spec_helper.rb
@@ -1,0 +1,8 @@
+require 'bundler/setup'
+Bundler.setup
+
+require 'kube-dsl'
+
+RSpec.configure do |config|
+  # some (optional) config here
+end


### PR DESCRIPTION
### NOT FINAL PR
I need help me out how are the "attributes" are set in the DSL.

For example we have `KubeDSL::DSL::V1::Namespace`
1. How to set valid `object` into `metadata`?
2. How to set invalid `object` into `metadata`?

Please add a comment in the PR and point me to the JSON you showed in the call :)

Any feedback is appreciated 🙏 