### PR TITLE
WIP: Update apiextensions/v1 for JSON class

### DIFF
--- a/lib/kube-dsl/dsl/apiextensions/v1.rb
+++ b/lib/kube-dsl/dsl/apiextensions/v1.rb
@@ -12,6 +12,7 @@ module KubeDSL::DSL::Apiextensions::V1
   autoload :CustomResourceSubresources, 'kube-dsl/dsl/apiextensions/v1/custom_resource_subresources'
   autoload :CustomResourceValidation, 'kube-dsl/dsl/apiextensions/v1/custom_resource_validation'
   autoload :ExternalDocumentation, 'kube-dsl/dsl/apiextensions/v1/external_documentation'
+  autoload :JSON, 'kube-dsl/dsl/apiextensions/v1/json'
   autoload :JSONSchemaProps, 'kube-dsl/dsl/apiextensions/v1/json_schema_props'
   autoload :ServiceReference, 'kube-dsl/dsl/apiextensions/v1/service_reference'
   autoload :WebhookClientConfig, 'kube-dsl/dsl/apiextensions/v1/webhook_client_config'

--- a/lib/kube-dsl/dsl/apiextensions/v1/json_schema_props.rb
+++ b/lib/kube-dsl/dsl/apiextensions/v1/json_schema_props.rb
@@ -4,13 +4,13 @@ module KubeDSL::DSL::Apiextensions::V1
   class JSONSchemaProps < ::KubeDSL::DSLObject
     value_field :additional_items
     value_field :additional_properties
-    array_field(:all_of) { KubeDSL::DSL::Apiextensions::V1::JSONSchemaProps.new }
-    array_field(:any_of) { KubeDSL::DSL::Apiextensions::V1::JSONSchemaProps.new }
+    array_field(:all_ofs) { KubeDSL::DSL::Apiextensions::V1::JSONSchemaProps.new }
+    array_field(:any_ofs) { KubeDSL::DSL::Apiextensions::V1::JSONSchemaProps.new }
     value_field :default
     key_value_field(:definitions, format: :string)
     key_value_field(:dependencies, format: :string)
     value_field :description
-    array_field(:enum) { KubeDSL::DSL::Apiextensions::V1::JSON.new }
+    array_field(:enums) { KubeDSL::DSL::Apiextensions::V1::JSON.new }
     value_field :example
     value_field :exclusive_maximum
     value_field :exclusive_minimum
@@ -29,7 +29,7 @@ module KubeDSL::DSL::Apiextensions::V1
     value_field :multiple_of
     object_field(:not_field) { KubeDSL::DSL::Apiextensions::V1::JSONSchemaProps.new }
     value_field :nullable
-    array_field(:one_of) { KubeDSL::DSL::Apiextensions::V1::JSONSchemaProps.new }
+    array_field(:one_ofs) { KubeDSL::DSL::Apiextensions::V1::JSONSchemaProps.new }
     value_field :pattern
     key_value_field(:pattern_properties, format: :string)
     key_value_field(:properties, format: :string)

--- a/lib/kube-dsl/dsl/apiextensions/v1/json_schema_props.rb
+++ b/lib/kube-dsl/dsl/apiextensions/v1/json_schema_props.rb
@@ -100,7 +100,7 @@ module KubeDSL::DSL::Apiextensions::V1
         result[:example] = example
         result[:exclusiveMaximum] = exclusive_maximum
         result[:exclusiveMinimum] = exclusive_minimum
-        result[:externalDocs] = external_docs.serialize
+        #result[:externalDocs] = external_docs.serialize
         result[:format] = format
         result[:id] = id
         result[:items] = items
@@ -113,7 +113,7 @@ module KubeDSL::DSL::Apiextensions::V1
         result[:minProperties] = min_properties
         result[:minimum] = minimum
         result[:multipleOf] = multiple_of
-        result[:not] = not_field.serialize
+        # result[:not] = not_field.serialize
         result[:nullable] = nullable
         result[:oneOf] = one_ofs.map(&:serialize)
         result[:pattern] = pattern


### PR DESCRIPTION
I'm not certain if this was a generated file, or if this was just missed when it was defined

Working against the main branch, I got this error:
```
/Users/kingdonb/.rvm/gems/ruby-2.7.5/bundler/gems/kube-dsl-507696e0e2b9/lib/kube-dsl/dsl/apiextensions/v1/json_schema_props.rb:55:in `<class:JSONSchemaProps>': uninitialized constant KubeDSL::DSL::Apiextensions::V1::JSON (NameError)
```

(Today, I am defining a CustomResourceDefinition in kube-dsl!)