### PR TITLE
Fix handling of number types

### DIFF
--- a/lib/kube-dsl/rbi_helpers.rb
+++ b/lib/kube-dsl/rbi_helpers.rb
@@ -5,7 +5,7 @@ module KubeDSL
 
     TYPE_MAP = {
       'boolean' => 'T::Boolean',
-      'number' => 'Integer'
+      'number' => 'T.any(Integer, Float)'
     }
 
     TYPE_MAP.freeze

--- a/lib/kube-dsl/validations.rb
+++ b/lib/kube-dsl/validations.rb
@@ -88,6 +88,8 @@ module KubeDSL
             [String]
           when :integer
             [Integer]
+          when :number
+            [Integer, Float]
           when :boolean
             [TrueClass, FalseClass]
           else

--- a/rbi/kube-dsl.rbi
+++ b/rbi/kube-dsl.rbi
@@ -2248,7 +2248,7 @@ module KubeDSL
           sig { params(val: T.nilable(Integer)).returns(Integer) }
           def max_properties(val = nil); end
 
-          sig { params(val: T.nilable(Integer)).returns(Integer) }
+          sig { params(val: T.nilable(T.any(Integer, Float))).returns(T.any(Integer, Float)) }
           def maximum(val = nil); end
 
           sig { params(val: T.nilable(Integer)).returns(Integer) }
@@ -2260,10 +2260,10 @@ module KubeDSL
           sig { params(val: T.nilable(Integer)).returns(Integer) }
           def min_properties(val = nil); end
 
-          sig { params(val: T.nilable(Integer)).returns(Integer) }
+          sig { params(val: T.nilable(T.any(Integer, Float))).returns(T.any(Integer, Float)) }
           def minimum(val = nil); end
 
-          sig { params(val: T.nilable(Integer)).returns(Integer) }
+          sig { params(val: T.nilable(T.any(Integer, Float))).returns(T.any(Integer, Float)) }
           def multiple_of(val = nil); end
 
           sig { returns(KubeDSL::DSL::Apiextensions::V1::JSONSchemaProps) }

--- a/sorbet/rbi/kube-dsl/dsl/apiextensions/v1/json_schema_props.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/apiextensions/v1/json_schema_props.rbi
@@ -94,7 +94,7 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(Integer)).returns(Integer) }
           def max_properties(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { params(val: T.nilable(Integer)).returns(Integer) }
+          T::Sig::WithoutRuntime.sig { params(val: T.nilable(T.any(Integer, Float))).returns(T.any(Integer, Float)) }
           def maximum(val = nil); end
 
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(Integer)).returns(Integer) }
@@ -106,10 +106,10 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(Integer)).returns(Integer) }
           def min_properties(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { params(val: T.nilable(Integer)).returns(Integer) }
+          T::Sig::WithoutRuntime.sig { params(val: T.nilable(T.any(Integer, Float))).returns(T.any(Integer, Float)) }
           def minimum(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { params(val: T.nilable(Integer)).returns(Integer) }
+          T::Sig::WithoutRuntime.sig { params(val: T.nilable(T.any(Integer, Float))).returns(T.any(Integer, Float)) }
           def multiple_of(val = nil); end
 
           T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Apiextensions::V1::JSONSchemaProps) }


### PR DESCRIPTION
Noticed on a CRD that `number` (not to be confused with `integer`) is not handled correctly and is treated as `Integer` in the RBIs as well has not having a validator

`KubeDSL.json_schema_props.valid?` is probably a good test case for this (albeit probably not much of a real-world practical example), though seems like that has another unrelated issue where that errors on `all_ofs`.