### PR TITLE
Fix Sorbet block typing

### DIFF
--- a/lib/kube-dsl/dsl_object.rb
+++ b/lib/kube-dsl/dsl_object.rb
@@ -7,7 +7,7 @@ module KubeDSL
     extend ::KubeDSL::ValueFields
     extend ::KubeDSL::Validations
 
-    T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.void)).void }
+    T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(::KubeDSL::DSLObject).void)).void }
     def initialize(&block)
       instance_eval(&block) if block
     end

--- a/lib/kube-dsl/entrypoint_builder.rb
+++ b/lib/kube-dsl/entrypoint_builder.rb
@@ -42,8 +42,9 @@ module KubeDSL
         next if block && !block.call(resource, ns)
 
         method_name = method_name_for(resource)
+        resource_type = "::#{ns}::#{resource.ref.kind}"
 
-        rbi_code << "#{indent}T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::#{ns}::#{resource.ref.kind}) }\n"
+        rbi_code << "#{indent}T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(#{resource_type}).void).returns(#{resource_type}) }\n"
         rbi_code << "#{indent}def #{method_name}(&block); end\n\n"
       end
 

--- a/lib/kube-dsl/key_value_field_res.rb
+++ b/lib/kube-dsl/key_value_field_res.rb
@@ -22,7 +22,7 @@ module KubeDSL
 
     def fields_to_rbi(_inflector)
       [
-        "T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }",
+        "T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }",
         "def #{underscore(name)}(&block); end"
       ]
     end

--- a/lib/kube-dsl/object_field_res.rb
+++ b/lib/kube-dsl/object_field_res.rb
@@ -18,8 +18,8 @@ module KubeDSL
 
     def fields_to_rbi(_inflector)
       [
-        "T::Sig::WithoutRuntime.sig { returns(#{ruby_type}) }",
-        "def #{ruby_safe_name}; end",
+        "T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(#{ruby_type}).void)).returns(#{ruby_type}) }",
+        "def #{ruby_safe_name}(&block); end",
         "",
         "T::Sig::WithoutRuntime.sig { returns(T::Boolean) }",
         "def #{ruby_safe_name}_present?; end"

--- a/rbi/kube-dsl.rbi
+++ b/rbi/kube-dsl.rbi
@@ -5,7 +5,7 @@ module KubeDSL
     extend ::KubeDSL::ValueFields
     extend ::KubeDSL::Validations
 
-    sig { params(block: T.nilable(T.proc.void)).void }
+    sig { params(block: T.nilable(T.proc.bind(::KubeDSL::DSLObject).void)).void }
     def initialize(&block); end
 
     sig { returns(::KubeDSL::Resource) }
@@ -250,1258 +250,1258 @@ module KubeDSL
   end
 
   module Entrypoint
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Admissionregistration::V1::MutatingWebhook) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Admissionregistration::V1::MutatingWebhook).void).returns(::KubeDSL::DSL::Admissionregistration::V1::MutatingWebhook) }
     def mutating_webhook(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Admissionregistration::V1::MutatingWebhookConfiguration) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Admissionregistration::V1::MutatingWebhookConfiguration).void).returns(::KubeDSL::DSL::Admissionregistration::V1::MutatingWebhookConfiguration) }
     def mutating_webhook_configuration(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Admissionregistration::V1::MutatingWebhookConfigurationList) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Admissionregistration::V1::MutatingWebhookConfigurationList).void).returns(::KubeDSL::DSL::Admissionregistration::V1::MutatingWebhookConfigurationList) }
     def mutating_webhook_configuration_list(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Admissionregistration::V1::RuleWithOperations) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Admissionregistration::V1::RuleWithOperations).void).returns(::KubeDSL::DSL::Admissionregistration::V1::RuleWithOperations) }
     def rule_with_operations(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Admissionregistration::V1::ServiceReference) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Admissionregistration::V1::ServiceReference).void).returns(::KubeDSL::DSL::Admissionregistration::V1::ServiceReference) }
     def admissionregistration_v1_service_reference(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Admissionregistration::V1::ValidatingWebhook) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Admissionregistration::V1::ValidatingWebhook).void).returns(::KubeDSL::DSL::Admissionregistration::V1::ValidatingWebhook) }
     def validating_webhook(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Admissionregistration::V1::ValidatingWebhookConfiguration) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Admissionregistration::V1::ValidatingWebhookConfiguration).void).returns(::KubeDSL::DSL::Admissionregistration::V1::ValidatingWebhookConfiguration) }
     def validating_webhook_configuration(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Admissionregistration::V1::ValidatingWebhookConfigurationList) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Admissionregistration::V1::ValidatingWebhookConfigurationList).void).returns(::KubeDSL::DSL::Admissionregistration::V1::ValidatingWebhookConfigurationList) }
     def validating_webhook_configuration_list(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Admissionregistration::V1::WebhookClientConfig) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Admissionregistration::V1::WebhookClientConfig).void).returns(::KubeDSL::DSL::Admissionregistration::V1::WebhookClientConfig) }
     def admissionregistration_v1_webhook_client_config(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::ControllerRevision) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::ControllerRevision).void).returns(::KubeDSL::DSL::Apps::V1::ControllerRevision) }
     def controller_revision(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::ControllerRevisionList) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::ControllerRevisionList).void).returns(::KubeDSL::DSL::Apps::V1::ControllerRevisionList) }
     def controller_revision_list(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::DaemonSet) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::DaemonSet).void).returns(::KubeDSL::DSL::Apps::V1::DaemonSet) }
     def daemon_set(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::DaemonSetCondition) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::DaemonSetCondition).void).returns(::KubeDSL::DSL::Apps::V1::DaemonSetCondition) }
     def daemon_set_condition(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::DaemonSetList) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::DaemonSetList).void).returns(::KubeDSL::DSL::Apps::V1::DaemonSetList) }
     def daemon_set_list(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::DaemonSetSpec) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::DaemonSetSpec).void).returns(::KubeDSL::DSL::Apps::V1::DaemonSetSpec) }
     def daemon_set_spec(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::DaemonSetStatus) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::DaemonSetStatus).void).returns(::KubeDSL::DSL::Apps::V1::DaemonSetStatus) }
     def daemon_set_status(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::DaemonSetUpdateStrategy) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::DaemonSetUpdateStrategy).void).returns(::KubeDSL::DSL::Apps::V1::DaemonSetUpdateStrategy) }
     def daemon_set_update_strategy(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::Deployment) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::Deployment).void).returns(::KubeDSL::DSL::Apps::V1::Deployment) }
     def deployment(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::DeploymentCondition) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::DeploymentCondition).void).returns(::KubeDSL::DSL::Apps::V1::DeploymentCondition) }
     def deployment_condition(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::DeploymentList) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::DeploymentList).void).returns(::KubeDSL::DSL::Apps::V1::DeploymentList) }
     def deployment_list(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::DeploymentSpec) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::DeploymentSpec).void).returns(::KubeDSL::DSL::Apps::V1::DeploymentSpec) }
     def deployment_spec(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::DeploymentStatus) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::DeploymentStatus).void).returns(::KubeDSL::DSL::Apps::V1::DeploymentStatus) }
     def deployment_status(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::DeploymentStrategy) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::DeploymentStrategy).void).returns(::KubeDSL::DSL::Apps::V1::DeploymentStrategy) }
     def deployment_strategy(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::ReplicaSet) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::ReplicaSet).void).returns(::KubeDSL::DSL::Apps::V1::ReplicaSet) }
     def replica_set(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::ReplicaSetCondition) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::ReplicaSetCondition).void).returns(::KubeDSL::DSL::Apps::V1::ReplicaSetCondition) }
     def replica_set_condition(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::ReplicaSetList) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::ReplicaSetList).void).returns(::KubeDSL::DSL::Apps::V1::ReplicaSetList) }
     def replica_set_list(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::ReplicaSetSpec) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::ReplicaSetSpec).void).returns(::KubeDSL::DSL::Apps::V1::ReplicaSetSpec) }
     def replica_set_spec(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::ReplicaSetStatus) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::ReplicaSetStatus).void).returns(::KubeDSL::DSL::Apps::V1::ReplicaSetStatus) }
     def replica_set_status(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::RollingUpdateDaemonSet) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::RollingUpdateDaemonSet).void).returns(::KubeDSL::DSL::Apps::V1::RollingUpdateDaemonSet) }
     def rolling_update_daemon_set(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::RollingUpdateDeployment) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::RollingUpdateDeployment).void).returns(::KubeDSL::DSL::Apps::V1::RollingUpdateDeployment) }
     def rolling_update_deployment(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::RollingUpdateStatefulSetStrategy) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::RollingUpdateStatefulSetStrategy).void).returns(::KubeDSL::DSL::Apps::V1::RollingUpdateStatefulSetStrategy) }
     def rolling_update_stateful_set_strategy(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::StatefulSet) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::StatefulSet).void).returns(::KubeDSL::DSL::Apps::V1::StatefulSet) }
     def stateful_set(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::StatefulSetCondition) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::StatefulSetCondition).void).returns(::KubeDSL::DSL::Apps::V1::StatefulSetCondition) }
     def stateful_set_condition(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::StatefulSetList) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::StatefulSetList).void).returns(::KubeDSL::DSL::Apps::V1::StatefulSetList) }
     def stateful_set_list(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::StatefulSetPersistentVolumeClaimRetentionPolicy) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::StatefulSetPersistentVolumeClaimRetentionPolicy).void).returns(::KubeDSL::DSL::Apps::V1::StatefulSetPersistentVolumeClaimRetentionPolicy) }
     def stateful_set_persistent_volume_claim_retention_policy(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::StatefulSetSpec) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::StatefulSetSpec).void).returns(::KubeDSL::DSL::Apps::V1::StatefulSetSpec) }
     def stateful_set_spec(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::StatefulSetStatus) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::StatefulSetStatus).void).returns(::KubeDSL::DSL::Apps::V1::StatefulSetStatus) }
     def stateful_set_status(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::StatefulSetUpdateStrategy) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::StatefulSetUpdateStrategy).void).returns(::KubeDSL::DSL::Apps::V1::StatefulSetUpdateStrategy) }
     def stateful_set_update_strategy(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Authentication::V1::BoundObjectReference) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Authentication::V1::BoundObjectReference).void).returns(::KubeDSL::DSL::Authentication::V1::BoundObjectReference) }
     def bound_object_reference(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Authentication::V1::TokenRequest) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Authentication::V1::TokenRequest).void).returns(::KubeDSL::DSL::Authentication::V1::TokenRequest) }
     def authentication_v1_token_request(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Authentication::V1::TokenRequestSpec) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Authentication::V1::TokenRequestSpec).void).returns(::KubeDSL::DSL::Authentication::V1::TokenRequestSpec) }
     def token_request_spec(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Authentication::V1::TokenRequestStatus) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Authentication::V1::TokenRequestStatus).void).returns(::KubeDSL::DSL::Authentication::V1::TokenRequestStatus) }
     def token_request_status(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Authentication::V1::TokenReview) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Authentication::V1::TokenReview).void).returns(::KubeDSL::DSL::Authentication::V1::TokenReview) }
     def token_review(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Authentication::V1::TokenReviewSpec) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Authentication::V1::TokenReviewSpec).void).returns(::KubeDSL::DSL::Authentication::V1::TokenReviewSpec) }
     def token_review_spec(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Authentication::V1::TokenReviewStatus) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Authentication::V1::TokenReviewStatus).void).returns(::KubeDSL::DSL::Authentication::V1::TokenReviewStatus) }
     def token_review_status(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Authentication::V1::UserInfo) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Authentication::V1::UserInfo).void).returns(::KubeDSL::DSL::Authentication::V1::UserInfo) }
     def user_info(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Authorization::V1::LocalSubjectAccessReview) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Authorization::V1::LocalSubjectAccessReview).void).returns(::KubeDSL::DSL::Authorization::V1::LocalSubjectAccessReview) }
     def local_subject_access_review(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Authorization::V1::NonResourceAttributes) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Authorization::V1::NonResourceAttributes).void).returns(::KubeDSL::DSL::Authorization::V1::NonResourceAttributes) }
     def non_resource_attributes(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Authorization::V1::NonResourceRule) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Authorization::V1::NonResourceRule).void).returns(::KubeDSL::DSL::Authorization::V1::NonResourceRule) }
     def non_resource_rule(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Authorization::V1::ResourceAttributes) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Authorization::V1::ResourceAttributes).void).returns(::KubeDSL::DSL::Authorization::V1::ResourceAttributes) }
     def resource_attributes(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Authorization::V1::ResourceRule) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Authorization::V1::ResourceRule).void).returns(::KubeDSL::DSL::Authorization::V1::ResourceRule) }
     def resource_rule(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Authorization::V1::SelfSubjectAccessReview) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Authorization::V1::SelfSubjectAccessReview).void).returns(::KubeDSL::DSL::Authorization::V1::SelfSubjectAccessReview) }
     def self_subject_access_review(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Authorization::V1::SelfSubjectAccessReviewSpec) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Authorization::V1::SelfSubjectAccessReviewSpec).void).returns(::KubeDSL::DSL::Authorization::V1::SelfSubjectAccessReviewSpec) }
     def self_subject_access_review_spec(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Authorization::V1::SelfSubjectRulesReview) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Authorization::V1::SelfSubjectRulesReview).void).returns(::KubeDSL::DSL::Authorization::V1::SelfSubjectRulesReview) }
     def self_subject_rules_review(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Authorization::V1::SelfSubjectRulesReviewSpec) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Authorization::V1::SelfSubjectRulesReviewSpec).void).returns(::KubeDSL::DSL::Authorization::V1::SelfSubjectRulesReviewSpec) }
     def self_subject_rules_review_spec(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Authorization::V1::SubjectAccessReview) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Authorization::V1::SubjectAccessReview).void).returns(::KubeDSL::DSL::Authorization::V1::SubjectAccessReview) }
     def subject_access_review(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Authorization::V1::SubjectAccessReviewSpec) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Authorization::V1::SubjectAccessReviewSpec).void).returns(::KubeDSL::DSL::Authorization::V1::SubjectAccessReviewSpec) }
     def subject_access_review_spec(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Authorization::V1::SubjectAccessReviewStatus) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Authorization::V1::SubjectAccessReviewStatus).void).returns(::KubeDSL::DSL::Authorization::V1::SubjectAccessReviewStatus) }
     def subject_access_review_status(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Authorization::V1::SubjectRulesReviewStatus) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Authorization::V1::SubjectRulesReviewStatus).void).returns(::KubeDSL::DSL::Authorization::V1::SubjectRulesReviewStatus) }
     def subject_rules_review_status(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V1::CrossVersionObjectReference) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V1::CrossVersionObjectReference).void).returns(::KubeDSL::DSL::Autoscaling::V1::CrossVersionObjectReference) }
     def autoscaling_v1_cross_version_object_reference(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V1::HorizontalPodAutoscaler) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V1::HorizontalPodAutoscaler).void).returns(::KubeDSL::DSL::Autoscaling::V1::HorizontalPodAutoscaler) }
     def autoscaling_v1_horizontal_pod_autoscaler(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V1::HorizontalPodAutoscalerList) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V1::HorizontalPodAutoscalerList).void).returns(::KubeDSL::DSL::Autoscaling::V1::HorizontalPodAutoscalerList) }
     def autoscaling_v1_horizontal_pod_autoscaler_list(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V1::HorizontalPodAutoscalerSpec) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V1::HorizontalPodAutoscalerSpec).void).returns(::KubeDSL::DSL::Autoscaling::V1::HorizontalPodAutoscalerSpec) }
     def autoscaling_v1_horizontal_pod_autoscaler_spec(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V1::HorizontalPodAutoscalerStatus) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V1::HorizontalPodAutoscalerStatus).void).returns(::KubeDSL::DSL::Autoscaling::V1::HorizontalPodAutoscalerStatus) }
     def autoscaling_v1_horizontal_pod_autoscaler_status(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V1::Scale) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V1::Scale).void).returns(::KubeDSL::DSL::Autoscaling::V1::Scale) }
     def scale(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V1::ScaleSpec) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V1::ScaleSpec).void).returns(::KubeDSL::DSL::Autoscaling::V1::ScaleSpec) }
     def scale_spec(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V1::ScaleStatus) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V1::ScaleStatus).void).returns(::KubeDSL::DSL::Autoscaling::V1::ScaleStatus) }
     def scale_status(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V2::ContainerResourceMetricSource) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V2::ContainerResourceMetricSource).void).returns(::KubeDSL::DSL::Autoscaling::V2::ContainerResourceMetricSource) }
     def container_resource_metric_source(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V2::ContainerResourceMetricStatus) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V2::ContainerResourceMetricStatus).void).returns(::KubeDSL::DSL::Autoscaling::V2::ContainerResourceMetricStatus) }
     def container_resource_metric_status(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V2::CrossVersionObjectReference) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V2::CrossVersionObjectReference).void).returns(::KubeDSL::DSL::Autoscaling::V2::CrossVersionObjectReference) }
     def autoscaling_v2_cross_version_object_reference(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V2::ExternalMetricSource) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V2::ExternalMetricSource).void).returns(::KubeDSL::DSL::Autoscaling::V2::ExternalMetricSource) }
     def external_metric_source(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V2::ExternalMetricStatus) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V2::ExternalMetricStatus).void).returns(::KubeDSL::DSL::Autoscaling::V2::ExternalMetricStatus) }
     def external_metric_status(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V2::HPAScalingPolicy) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V2::HPAScalingPolicy).void).returns(::KubeDSL::DSL::Autoscaling::V2::HPAScalingPolicy) }
     def hpa_scaling_policy(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V2::HPAScalingRules) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V2::HPAScalingRules).void).returns(::KubeDSL::DSL::Autoscaling::V2::HPAScalingRules) }
     def hpa_scaling_rules(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscaler) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscaler).void).returns(::KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscaler) }
     def autoscaling_v2_horizontal_pod_autoscaler(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscalerBehavior) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscalerBehavior).void).returns(::KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscalerBehavior) }
     def horizontal_pod_autoscaler_behavior(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscalerCondition) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscalerCondition).void).returns(::KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscalerCondition) }
     def horizontal_pod_autoscaler_condition(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscalerList) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscalerList).void).returns(::KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscalerList) }
     def autoscaling_v2_horizontal_pod_autoscaler_list(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscalerSpec) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscalerSpec).void).returns(::KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscalerSpec) }
     def autoscaling_v2_horizontal_pod_autoscaler_spec(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscalerStatus) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscalerStatus).void).returns(::KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscalerStatus) }
     def autoscaling_v2_horizontal_pod_autoscaler_status(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V2::MetricIdentifier) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V2::MetricIdentifier).void).returns(::KubeDSL::DSL::Autoscaling::V2::MetricIdentifier) }
     def metric_identifier(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V2::MetricSpec) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V2::MetricSpec).void).returns(::KubeDSL::DSL::Autoscaling::V2::MetricSpec) }
     def metric_spec(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V2::MetricStatus) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V2::MetricStatus).void).returns(::KubeDSL::DSL::Autoscaling::V2::MetricStatus) }
     def metric_status(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V2::MetricTarget) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V2::MetricTarget).void).returns(::KubeDSL::DSL::Autoscaling::V2::MetricTarget) }
     def metric_target(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V2::MetricValueStatus) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V2::MetricValueStatus).void).returns(::KubeDSL::DSL::Autoscaling::V2::MetricValueStatus) }
     def metric_value_status(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V2::ObjectMetricSource) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V2::ObjectMetricSource).void).returns(::KubeDSL::DSL::Autoscaling::V2::ObjectMetricSource) }
     def object_metric_source(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V2::ObjectMetricStatus) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V2::ObjectMetricStatus).void).returns(::KubeDSL::DSL::Autoscaling::V2::ObjectMetricStatus) }
     def object_metric_status(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V2::PodsMetricSource) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V2::PodsMetricSource).void).returns(::KubeDSL::DSL::Autoscaling::V2::PodsMetricSource) }
     def pods_metric_source(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V2::PodsMetricStatus) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V2::PodsMetricStatus).void).returns(::KubeDSL::DSL::Autoscaling::V2::PodsMetricStatus) }
     def pods_metric_status(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V2::ResourceMetricSource) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V2::ResourceMetricSource).void).returns(::KubeDSL::DSL::Autoscaling::V2::ResourceMetricSource) }
     def resource_metric_source(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V2::ResourceMetricStatus) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V2::ResourceMetricStatus).void).returns(::KubeDSL::DSL::Autoscaling::V2::ResourceMetricStatus) }
     def resource_metric_status(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Batch::V1::CronJob) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Batch::V1::CronJob).void).returns(::KubeDSL::DSL::Batch::V1::CronJob) }
     def cron_job(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Batch::V1::CronJobList) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Batch::V1::CronJobList).void).returns(::KubeDSL::DSL::Batch::V1::CronJobList) }
     def cron_job_list(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Batch::V1::CronJobSpec) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Batch::V1::CronJobSpec).void).returns(::KubeDSL::DSL::Batch::V1::CronJobSpec) }
     def cron_job_spec(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Batch::V1::CronJobStatus) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Batch::V1::CronJobStatus).void).returns(::KubeDSL::DSL::Batch::V1::CronJobStatus) }
     def cron_job_status(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Batch::V1::Job) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Batch::V1::Job).void).returns(::KubeDSL::DSL::Batch::V1::Job) }
     def job(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Batch::V1::JobCondition) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Batch::V1::JobCondition).void).returns(::KubeDSL::DSL::Batch::V1::JobCondition) }
     def job_condition(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Batch::V1::JobList) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Batch::V1::JobList).void).returns(::KubeDSL::DSL::Batch::V1::JobList) }
     def job_list(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Batch::V1::JobSpec) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Batch::V1::JobSpec).void).returns(::KubeDSL::DSL::Batch::V1::JobSpec) }
     def job_spec(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Batch::V1::JobStatus) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Batch::V1::JobStatus).void).returns(::KubeDSL::DSL::Batch::V1::JobStatus) }
     def job_status(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Batch::V1::JobTemplateSpec) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Batch::V1::JobTemplateSpec).void).returns(::KubeDSL::DSL::Batch::V1::JobTemplateSpec) }
     def job_template_spec(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Batch::V1::UncountedTerminatedPods) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Batch::V1::UncountedTerminatedPods).void).returns(::KubeDSL::DSL::Batch::V1::UncountedTerminatedPods) }
     def uncounted_terminated_pods(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Certificates::V1::CertificateSigningRequest) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Certificates::V1::CertificateSigningRequest).void).returns(::KubeDSL::DSL::Certificates::V1::CertificateSigningRequest) }
     def certificate_signing_request(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Certificates::V1::CertificateSigningRequestCondition) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Certificates::V1::CertificateSigningRequestCondition).void).returns(::KubeDSL::DSL::Certificates::V1::CertificateSigningRequestCondition) }
     def certificate_signing_request_condition(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Certificates::V1::CertificateSigningRequestList) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Certificates::V1::CertificateSigningRequestList).void).returns(::KubeDSL::DSL::Certificates::V1::CertificateSigningRequestList) }
     def certificate_signing_request_list(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Certificates::V1::CertificateSigningRequestSpec) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Certificates::V1::CertificateSigningRequestSpec).void).returns(::KubeDSL::DSL::Certificates::V1::CertificateSigningRequestSpec) }
     def certificate_signing_request_spec(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Certificates::V1::CertificateSigningRequestStatus) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Certificates::V1::CertificateSigningRequestStatus).void).returns(::KubeDSL::DSL::Certificates::V1::CertificateSigningRequestStatus) }
     def certificate_signing_request_status(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Coordination::V1::Lease) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Coordination::V1::Lease).void).returns(::KubeDSL::DSL::Coordination::V1::Lease) }
     def lease(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Coordination::V1::LeaseList) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Coordination::V1::LeaseList).void).returns(::KubeDSL::DSL::Coordination::V1::LeaseList) }
     def lease_list(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Coordination::V1::LeaseSpec) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Coordination::V1::LeaseSpec).void).returns(::KubeDSL::DSL::Coordination::V1::LeaseSpec) }
     def lease_spec(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::AWSElasticBlockStoreVolumeSource) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::AWSElasticBlockStoreVolumeSource).void).returns(::KubeDSL::DSL::V1::AWSElasticBlockStoreVolumeSource) }
     def aws_elastic_block_store_volume_source(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::Affinity) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::Affinity).void).returns(::KubeDSL::DSL::V1::Affinity) }
     def affinity(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::AttachedVolume) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::AttachedVolume).void).returns(::KubeDSL::DSL::V1::AttachedVolume) }
     def attached_volume(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::AzureDiskVolumeSource) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::AzureDiskVolumeSource).void).returns(::KubeDSL::DSL::V1::AzureDiskVolumeSource) }
     def azure_disk_volume_source(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::AzureFilePersistentVolumeSource) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::AzureFilePersistentVolumeSource).void).returns(::KubeDSL::DSL::V1::AzureFilePersistentVolumeSource) }
     def azure_file_persistent_volume_source(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::AzureFileVolumeSource) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::AzureFileVolumeSource).void).returns(::KubeDSL::DSL::V1::AzureFileVolumeSource) }
     def azure_file_volume_source(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::Binding) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::Binding).void).returns(::KubeDSL::DSL::V1::Binding) }
     def binding(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::CSIPersistentVolumeSource) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::CSIPersistentVolumeSource).void).returns(::KubeDSL::DSL::V1::CSIPersistentVolumeSource) }
     def csi_persistent_volume_source(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::CSIVolumeSource) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::CSIVolumeSource).void).returns(::KubeDSL::DSL::V1::CSIVolumeSource) }
     def csi_volume_source(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::Capabilities) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::Capabilities).void).returns(::KubeDSL::DSL::V1::Capabilities) }
     def capabilities(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::CephFSPersistentVolumeSource) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::CephFSPersistentVolumeSource).void).returns(::KubeDSL::DSL::V1::CephFSPersistentVolumeSource) }
     def ceph_fs_persistent_volume_source(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::CephFSVolumeSource) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::CephFSVolumeSource).void).returns(::KubeDSL::DSL::V1::CephFSVolumeSource) }
     def ceph_fs_volume_source(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::CinderPersistentVolumeSource) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::CinderPersistentVolumeSource).void).returns(::KubeDSL::DSL::V1::CinderPersistentVolumeSource) }
     def cinder_persistent_volume_source(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::CinderVolumeSource) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::CinderVolumeSource).void).returns(::KubeDSL::DSL::V1::CinderVolumeSource) }
     def cinder_volume_source(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ClientIPConfig) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ClientIPConfig).void).returns(::KubeDSL::DSL::V1::ClientIPConfig) }
     def client_ip_config(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ComponentCondition) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ComponentCondition).void).returns(::KubeDSL::DSL::V1::ComponentCondition) }
     def component_condition(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ComponentStatus) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ComponentStatus).void).returns(::KubeDSL::DSL::V1::ComponentStatus) }
     def component_status(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ComponentStatusList) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ComponentStatusList).void).returns(::KubeDSL::DSL::V1::ComponentStatusList) }
     def component_status_list(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ConfigMap) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ConfigMap).void).returns(::KubeDSL::DSL::V1::ConfigMap) }
     def config_map(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ConfigMapEnvSource) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ConfigMapEnvSource).void).returns(::KubeDSL::DSL::V1::ConfigMapEnvSource) }
     def config_map_env_source(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ConfigMapKeySelector) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ConfigMapKeySelector).void).returns(::KubeDSL::DSL::V1::ConfigMapKeySelector) }
     def config_map_key_selector(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ConfigMapList) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ConfigMapList).void).returns(::KubeDSL::DSL::V1::ConfigMapList) }
     def config_map_list(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ConfigMapNodeConfigSource) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ConfigMapNodeConfigSource).void).returns(::KubeDSL::DSL::V1::ConfigMapNodeConfigSource) }
     def config_map_node_config_source(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ConfigMapProjection) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ConfigMapProjection).void).returns(::KubeDSL::DSL::V1::ConfigMapProjection) }
     def config_map_projection(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ConfigMapVolumeSource) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ConfigMapVolumeSource).void).returns(::KubeDSL::DSL::V1::ConfigMapVolumeSource) }
     def config_map_volume_source(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::Container) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::Container).void).returns(::KubeDSL::DSL::V1::Container) }
     def container(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ContainerImage) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ContainerImage).void).returns(::KubeDSL::DSL::V1::ContainerImage) }
     def container_image(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ContainerPort) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ContainerPort).void).returns(::KubeDSL::DSL::V1::ContainerPort) }
     def container_port(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ContainerState) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ContainerState).void).returns(::KubeDSL::DSL::V1::ContainerState) }
     def container_state(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ContainerStateRunning) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ContainerStateRunning).void).returns(::KubeDSL::DSL::V1::ContainerStateRunning) }
     def container_state_running(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ContainerStateTerminated) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ContainerStateTerminated).void).returns(::KubeDSL::DSL::V1::ContainerStateTerminated) }
     def container_state_terminated(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ContainerStateWaiting) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ContainerStateWaiting).void).returns(::KubeDSL::DSL::V1::ContainerStateWaiting) }
     def container_state_waiting(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ContainerStatus) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ContainerStatus).void).returns(::KubeDSL::DSL::V1::ContainerStatus) }
     def container_status(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::DaemonEndpoint) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::DaemonEndpoint).void).returns(::KubeDSL::DSL::V1::DaemonEndpoint) }
     def daemon_endpoint(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::DownwardAPIProjection) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::DownwardAPIProjection).void).returns(::KubeDSL::DSL::V1::DownwardAPIProjection) }
     def downward_api_projection(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::DownwardAPIVolumeFile) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::DownwardAPIVolumeFile).void).returns(::KubeDSL::DSL::V1::DownwardAPIVolumeFile) }
     def downward_api_volume_file(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::DownwardAPIVolumeSource) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::DownwardAPIVolumeSource).void).returns(::KubeDSL::DSL::V1::DownwardAPIVolumeSource) }
     def downward_api_volume_source(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::EmptyDirVolumeSource) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::EmptyDirVolumeSource).void).returns(::KubeDSL::DSL::V1::EmptyDirVolumeSource) }
     def empty_dir_volume_source(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::EndpointAddress) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::EndpointAddress).void).returns(::KubeDSL::DSL::V1::EndpointAddress) }
     def endpoint_address(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::EndpointPort) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::EndpointPort).void).returns(::KubeDSL::DSL::V1::EndpointPort) }
     def v1_endpoint_port(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::EndpointSubset) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::EndpointSubset).void).returns(::KubeDSL::DSL::V1::EndpointSubset) }
     def endpoint_subset(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::Endpoints) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::Endpoints).void).returns(::KubeDSL::DSL::V1::Endpoints) }
     def endpoints(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::EndpointsList) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::EndpointsList).void).returns(::KubeDSL::DSL::V1::EndpointsList) }
     def endpoints_list(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::EnvFromSource) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::EnvFromSource).void).returns(::KubeDSL::DSL::V1::EnvFromSource) }
     def env_from_source(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::EnvVar) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::EnvVar).void).returns(::KubeDSL::DSL::V1::EnvVar) }
     def env_var(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::EnvVarSource) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::EnvVarSource).void).returns(::KubeDSL::DSL::V1::EnvVarSource) }
     def env_var_source(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::EphemeralContainer) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::EphemeralContainer).void).returns(::KubeDSL::DSL::V1::EphemeralContainer) }
     def ephemeral_container(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::EphemeralVolumeSource) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::EphemeralVolumeSource).void).returns(::KubeDSL::DSL::V1::EphemeralVolumeSource) }
     def ephemeral_volume_source(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::Event) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::Event).void).returns(::KubeDSL::DSL::V1::Event) }
     def v1_event(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::EventList) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::EventList).void).returns(::KubeDSL::DSL::V1::EventList) }
     def v1_event_list(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::EventSeries) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::EventSeries).void).returns(::KubeDSL::DSL::V1::EventSeries) }
     def v1_event_series(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::EventSource) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::EventSource).void).returns(::KubeDSL::DSL::V1::EventSource) }
     def event_source(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ExecAction) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ExecAction).void).returns(::KubeDSL::DSL::V1::ExecAction) }
     def exec_action(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::FCVolumeSource) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::FCVolumeSource).void).returns(::KubeDSL::DSL::V1::FCVolumeSource) }
     def fc_volume_source(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::FlexPersistentVolumeSource) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::FlexPersistentVolumeSource).void).returns(::KubeDSL::DSL::V1::FlexPersistentVolumeSource) }
     def flex_persistent_volume_source(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::FlexVolumeSource) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::FlexVolumeSource).void).returns(::KubeDSL::DSL::V1::FlexVolumeSource) }
     def flex_volume_source(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::FlockerVolumeSource) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::FlockerVolumeSource).void).returns(::KubeDSL::DSL::V1::FlockerVolumeSource) }
     def flocker_volume_source(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::GCEPersistentDiskVolumeSource) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::GCEPersistentDiskVolumeSource).void).returns(::KubeDSL::DSL::V1::GCEPersistentDiskVolumeSource) }
     def gce_persistent_disk_volume_source(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::GRPCAction) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::GRPCAction).void).returns(::KubeDSL::DSL::V1::GRPCAction) }
     def grpc_action(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::GitRepoVolumeSource) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::GitRepoVolumeSource).void).returns(::KubeDSL::DSL::V1::GitRepoVolumeSource) }
     def git_repo_volume_source(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::GlusterfsPersistentVolumeSource) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::GlusterfsPersistentVolumeSource).void).returns(::KubeDSL::DSL::V1::GlusterfsPersistentVolumeSource) }
     def glusterfs_persistent_volume_source(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::GlusterfsVolumeSource) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::GlusterfsVolumeSource).void).returns(::KubeDSL::DSL::V1::GlusterfsVolumeSource) }
     def glusterfs_volume_source(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::HTTPGetAction) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::HTTPGetAction).void).returns(::KubeDSL::DSL::V1::HTTPGetAction) }
     def http_get_action(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::HTTPHeader) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::HTTPHeader).void).returns(::KubeDSL::DSL::V1::HTTPHeader) }
     def http_header(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::HostAlias) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::HostAlias).void).returns(::KubeDSL::DSL::V1::HostAlias) }
     def host_alias(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::HostPathVolumeSource) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::HostPathVolumeSource).void).returns(::KubeDSL::DSL::V1::HostPathVolumeSource) }
     def host_path_volume_source(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ISCSIPersistentVolumeSource) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ISCSIPersistentVolumeSource).void).returns(::KubeDSL::DSL::V1::ISCSIPersistentVolumeSource) }
     def iscsi_persistent_volume_source(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ISCSIVolumeSource) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ISCSIVolumeSource).void).returns(::KubeDSL::DSL::V1::ISCSIVolumeSource) }
     def iscsi_volume_source(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::KeyToPath) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::KeyToPath).void).returns(::KubeDSL::DSL::V1::KeyToPath) }
     def key_to_path(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::Lifecycle) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::Lifecycle).void).returns(::KubeDSL::DSL::V1::Lifecycle) }
     def lifecycle(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::LifecycleHandler) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::LifecycleHandler).void).returns(::KubeDSL::DSL::V1::LifecycleHandler) }
     def lifecycle_handler(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::LimitRange) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::LimitRange).void).returns(::KubeDSL::DSL::V1::LimitRange) }
     def limit_range(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::LimitRangeItem) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::LimitRangeItem).void).returns(::KubeDSL::DSL::V1::LimitRangeItem) }
     def limit_range_item(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::LimitRangeList) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::LimitRangeList).void).returns(::KubeDSL::DSL::V1::LimitRangeList) }
     def limit_range_list(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::LimitRangeSpec) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::LimitRangeSpec).void).returns(::KubeDSL::DSL::V1::LimitRangeSpec) }
     def limit_range_spec(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::LoadBalancerIngress) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::LoadBalancerIngress).void).returns(::KubeDSL::DSL::V1::LoadBalancerIngress) }
     def load_balancer_ingress(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::LoadBalancerStatus) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::LoadBalancerStatus).void).returns(::KubeDSL::DSL::V1::LoadBalancerStatus) }
     def load_balancer_status(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::LocalObjectReference) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::LocalObjectReference).void).returns(::KubeDSL::DSL::V1::LocalObjectReference) }
     def local_object_reference(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::LocalVolumeSource) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::LocalVolumeSource).void).returns(::KubeDSL::DSL::V1::LocalVolumeSource) }
     def local_volume_source(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::NFSVolumeSource) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::NFSVolumeSource).void).returns(::KubeDSL::DSL::V1::NFSVolumeSource) }
     def nfs_volume_source(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::Namespace) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::Namespace).void).returns(::KubeDSL::DSL::V1::Namespace) }
     def namespace(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::NamespaceCondition) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::NamespaceCondition).void).returns(::KubeDSL::DSL::V1::NamespaceCondition) }
     def namespace_condition(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::NamespaceList) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::NamespaceList).void).returns(::KubeDSL::DSL::V1::NamespaceList) }
     def namespace_list(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::NamespaceSpec) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::NamespaceSpec).void).returns(::KubeDSL::DSL::V1::NamespaceSpec) }
     def namespace_spec(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::NamespaceStatus) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::NamespaceStatus).void).returns(::KubeDSL::DSL::V1::NamespaceStatus) }
     def namespace_status(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::Node) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::Node).void).returns(::KubeDSL::DSL::V1::Node) }
     def node(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::NodeAddress) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::NodeAddress).void).returns(::KubeDSL::DSL::V1::NodeAddress) }
     def node_address(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::NodeAffinity) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::NodeAffinity).void).returns(::KubeDSL::DSL::V1::NodeAffinity) }
     def node_affinity(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::NodeCondition) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::NodeCondition).void).returns(::KubeDSL::DSL::V1::NodeCondition) }
     def node_condition(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::NodeConfigSource) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::NodeConfigSource).void).returns(::KubeDSL::DSL::V1::NodeConfigSource) }
     def node_config_source(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::NodeConfigStatus) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::NodeConfigStatus).void).returns(::KubeDSL::DSL::V1::NodeConfigStatus) }
     def node_config_status(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::NodeDaemonEndpoints) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::NodeDaemonEndpoints).void).returns(::KubeDSL::DSL::V1::NodeDaemonEndpoints) }
     def node_daemon_endpoints(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::NodeList) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::NodeList).void).returns(::KubeDSL::DSL::V1::NodeList) }
     def node_list(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::NodeSelector) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::NodeSelector).void).returns(::KubeDSL::DSL::V1::NodeSelector) }
     def node_selector(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::NodeSelectorRequirement) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::NodeSelectorRequirement).void).returns(::KubeDSL::DSL::V1::NodeSelectorRequirement) }
     def node_selector_requirement(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::NodeSelectorTerm) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::NodeSelectorTerm).void).returns(::KubeDSL::DSL::V1::NodeSelectorTerm) }
     def node_selector_term(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::NodeSpec) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::NodeSpec).void).returns(::KubeDSL::DSL::V1::NodeSpec) }
     def node_spec(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::NodeStatus) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::NodeStatus).void).returns(::KubeDSL::DSL::V1::NodeStatus) }
     def node_status(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::NodeSystemInfo) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::NodeSystemInfo).void).returns(::KubeDSL::DSL::V1::NodeSystemInfo) }
     def node_system_info(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ObjectFieldSelector) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ObjectFieldSelector).void).returns(::KubeDSL::DSL::V1::ObjectFieldSelector) }
     def object_field_selector(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ObjectReference) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ObjectReference).void).returns(::KubeDSL::DSL::V1::ObjectReference) }
     def object_reference(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PersistentVolume) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PersistentVolume).void).returns(::KubeDSL::DSL::V1::PersistentVolume) }
     def persistent_volume(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PersistentVolumeClaim) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PersistentVolumeClaim).void).returns(::KubeDSL::DSL::V1::PersistentVolumeClaim) }
     def persistent_volume_claim(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PersistentVolumeClaimCondition) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PersistentVolumeClaimCondition).void).returns(::KubeDSL::DSL::V1::PersistentVolumeClaimCondition) }
     def persistent_volume_claim_condition(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PersistentVolumeClaimList) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PersistentVolumeClaimList).void).returns(::KubeDSL::DSL::V1::PersistentVolumeClaimList) }
     def persistent_volume_claim_list(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PersistentVolumeClaimSpec) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PersistentVolumeClaimSpec).void).returns(::KubeDSL::DSL::V1::PersistentVolumeClaimSpec) }
     def persistent_volume_claim_spec(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PersistentVolumeClaimStatus) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PersistentVolumeClaimStatus).void).returns(::KubeDSL::DSL::V1::PersistentVolumeClaimStatus) }
     def persistent_volume_claim_status(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PersistentVolumeClaimTemplate) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PersistentVolumeClaimTemplate).void).returns(::KubeDSL::DSL::V1::PersistentVolumeClaimTemplate) }
     def persistent_volume_claim_template(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PersistentVolumeClaimVolumeSource) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PersistentVolumeClaimVolumeSource).void).returns(::KubeDSL::DSL::V1::PersistentVolumeClaimVolumeSource) }
     def persistent_volume_claim_volume_source(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PersistentVolumeList) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PersistentVolumeList).void).returns(::KubeDSL::DSL::V1::PersistentVolumeList) }
     def persistent_volume_list(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PersistentVolumeSpec) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PersistentVolumeSpec).void).returns(::KubeDSL::DSL::V1::PersistentVolumeSpec) }
     def persistent_volume_spec(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PersistentVolumeStatus) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PersistentVolumeStatus).void).returns(::KubeDSL::DSL::V1::PersistentVolumeStatus) }
     def persistent_volume_status(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PhotonPersistentDiskVolumeSource) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PhotonPersistentDiskVolumeSource).void).returns(::KubeDSL::DSL::V1::PhotonPersistentDiskVolumeSource) }
     def photon_persistent_disk_volume_source(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::Pod) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::Pod).void).returns(::KubeDSL::DSL::V1::Pod) }
     def pod(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PodAffinity) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PodAffinity).void).returns(::KubeDSL::DSL::V1::PodAffinity) }
     def pod_affinity(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PodAffinityTerm) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PodAffinityTerm).void).returns(::KubeDSL::DSL::V1::PodAffinityTerm) }
     def pod_affinity_term(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PodAntiAffinity) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PodAntiAffinity).void).returns(::KubeDSL::DSL::V1::PodAntiAffinity) }
     def pod_anti_affinity(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PodCondition) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PodCondition).void).returns(::KubeDSL::DSL::V1::PodCondition) }
     def pod_condition(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PodDNSConfig) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PodDNSConfig).void).returns(::KubeDSL::DSL::V1::PodDNSConfig) }
     def pod_dns_config(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PodDNSConfigOption) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PodDNSConfigOption).void).returns(::KubeDSL::DSL::V1::PodDNSConfigOption) }
     def pod_dns_config_option(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PodIP) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PodIP).void).returns(::KubeDSL::DSL::V1::PodIP) }
     def pod_ip(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PodList) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PodList).void).returns(::KubeDSL::DSL::V1::PodList) }
     def pod_list(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PodOS) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PodOS).void).returns(::KubeDSL::DSL::V1::PodOS) }
     def pod_os(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PodReadinessGate) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PodReadinessGate).void).returns(::KubeDSL::DSL::V1::PodReadinessGate) }
     def pod_readiness_gate(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PodSecurityContext) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PodSecurityContext).void).returns(::KubeDSL::DSL::V1::PodSecurityContext) }
     def pod_security_context(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PodSpec) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PodSpec).void).returns(::KubeDSL::DSL::V1::PodSpec) }
     def pod_spec(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PodStatus) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PodStatus).void).returns(::KubeDSL::DSL::V1::PodStatus) }
     def pod_status(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PodTemplate) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PodTemplate).void).returns(::KubeDSL::DSL::V1::PodTemplate) }
     def pod_template(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PodTemplateList) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PodTemplateList).void).returns(::KubeDSL::DSL::V1::PodTemplateList) }
     def pod_template_list(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PodTemplateSpec) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PodTemplateSpec).void).returns(::KubeDSL::DSL::V1::PodTemplateSpec) }
     def pod_template_spec(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PortStatus) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PortStatus).void).returns(::KubeDSL::DSL::V1::PortStatus) }
     def port_status(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PortworxVolumeSource) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PortworxVolumeSource).void).returns(::KubeDSL::DSL::V1::PortworxVolumeSource) }
     def portworx_volume_source(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PreferredSchedulingTerm) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PreferredSchedulingTerm).void).returns(::KubeDSL::DSL::V1::PreferredSchedulingTerm) }
     def preferred_scheduling_term(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::Probe) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::Probe).void).returns(::KubeDSL::DSL::V1::Probe) }
     def probe(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ProjectedVolumeSource) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ProjectedVolumeSource).void).returns(::KubeDSL::DSL::V1::ProjectedVolumeSource) }
     def projected_volume_source(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::QuobyteVolumeSource) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::QuobyteVolumeSource).void).returns(::KubeDSL::DSL::V1::QuobyteVolumeSource) }
     def quobyte_volume_source(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::RBDPersistentVolumeSource) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::RBDPersistentVolumeSource).void).returns(::KubeDSL::DSL::V1::RBDPersistentVolumeSource) }
     def rbd_persistent_volume_source(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::RBDVolumeSource) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::RBDVolumeSource).void).returns(::KubeDSL::DSL::V1::RBDVolumeSource) }
     def rbd_volume_source(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ReplicationController) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ReplicationController).void).returns(::KubeDSL::DSL::V1::ReplicationController) }
     def replication_controller(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ReplicationControllerCondition) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ReplicationControllerCondition).void).returns(::KubeDSL::DSL::V1::ReplicationControllerCondition) }
     def replication_controller_condition(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ReplicationControllerList) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ReplicationControllerList).void).returns(::KubeDSL::DSL::V1::ReplicationControllerList) }
     def replication_controller_list(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ReplicationControllerSpec) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ReplicationControllerSpec).void).returns(::KubeDSL::DSL::V1::ReplicationControllerSpec) }
     def replication_controller_spec(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ReplicationControllerStatus) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ReplicationControllerStatus).void).returns(::KubeDSL::DSL::V1::ReplicationControllerStatus) }
     def replication_controller_status(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ResourceFieldSelector) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ResourceFieldSelector).void).returns(::KubeDSL::DSL::V1::ResourceFieldSelector) }
     def resource_field_selector(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ResourceQuota) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ResourceQuota).void).returns(::KubeDSL::DSL::V1::ResourceQuota) }
     def resource_quota(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ResourceQuotaList) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ResourceQuotaList).void).returns(::KubeDSL::DSL::V1::ResourceQuotaList) }
     def resource_quota_list(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ResourceQuotaSpec) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ResourceQuotaSpec).void).returns(::KubeDSL::DSL::V1::ResourceQuotaSpec) }
     def resource_quota_spec(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ResourceQuotaStatus) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ResourceQuotaStatus).void).returns(::KubeDSL::DSL::V1::ResourceQuotaStatus) }
     def resource_quota_status(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ResourceRequirements) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ResourceRequirements).void).returns(::KubeDSL::DSL::V1::ResourceRequirements) }
     def resource_requirements(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::SELinuxOptions) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::SELinuxOptions).void).returns(::KubeDSL::DSL::V1::SELinuxOptions) }
     def se_linux_options(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ScaleIOPersistentVolumeSource) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ScaleIOPersistentVolumeSource).void).returns(::KubeDSL::DSL::V1::ScaleIOPersistentVolumeSource) }
     def scale_io_persistent_volume_source(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ScaleIOVolumeSource) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ScaleIOVolumeSource).void).returns(::KubeDSL::DSL::V1::ScaleIOVolumeSource) }
     def scale_io_volume_source(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ScopeSelector) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ScopeSelector).void).returns(::KubeDSL::DSL::V1::ScopeSelector) }
     def scope_selector(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ScopedResourceSelectorRequirement) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ScopedResourceSelectorRequirement).void).returns(::KubeDSL::DSL::V1::ScopedResourceSelectorRequirement) }
     def scoped_resource_selector_requirement(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::SeccompProfile) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::SeccompProfile).void).returns(::KubeDSL::DSL::V1::SeccompProfile) }
     def seccomp_profile(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::Secret) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::Secret).void).returns(::KubeDSL::DSL::V1::Secret) }
     def secret(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::SecretEnvSource) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::SecretEnvSource).void).returns(::KubeDSL::DSL::V1::SecretEnvSource) }
     def secret_env_source(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::SecretKeySelector) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::SecretKeySelector).void).returns(::KubeDSL::DSL::V1::SecretKeySelector) }
     def secret_key_selector(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::SecretList) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::SecretList).void).returns(::KubeDSL::DSL::V1::SecretList) }
     def secret_list(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::SecretProjection) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::SecretProjection).void).returns(::KubeDSL::DSL::V1::SecretProjection) }
     def secret_projection(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::SecretReference) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::SecretReference).void).returns(::KubeDSL::DSL::V1::SecretReference) }
     def secret_reference(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::SecretVolumeSource) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::SecretVolumeSource).void).returns(::KubeDSL::DSL::V1::SecretVolumeSource) }
     def secret_volume_source(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::SecurityContext) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::SecurityContext).void).returns(::KubeDSL::DSL::V1::SecurityContext) }
     def security_context(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::Service) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::Service).void).returns(::KubeDSL::DSL::V1::Service) }
     def service(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ServiceAccount) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ServiceAccount).void).returns(::KubeDSL::DSL::V1::ServiceAccount) }
     def service_account(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ServiceAccountList) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ServiceAccountList).void).returns(::KubeDSL::DSL::V1::ServiceAccountList) }
     def service_account_list(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ServiceAccountTokenProjection) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ServiceAccountTokenProjection).void).returns(::KubeDSL::DSL::V1::ServiceAccountTokenProjection) }
     def service_account_token_projection(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ServiceList) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ServiceList).void).returns(::KubeDSL::DSL::V1::ServiceList) }
     def service_list(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ServicePort) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ServicePort).void).returns(::KubeDSL::DSL::V1::ServicePort) }
     def service_port(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ServiceSpec) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ServiceSpec).void).returns(::KubeDSL::DSL::V1::ServiceSpec) }
     def service_spec(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ServiceStatus) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ServiceStatus).void).returns(::KubeDSL::DSL::V1::ServiceStatus) }
     def service_status(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::SessionAffinityConfig) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::SessionAffinityConfig).void).returns(::KubeDSL::DSL::V1::SessionAffinityConfig) }
     def session_affinity_config(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::StorageOSPersistentVolumeSource) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::StorageOSPersistentVolumeSource).void).returns(::KubeDSL::DSL::V1::StorageOSPersistentVolumeSource) }
     def storage_os_persistent_volume_source(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::StorageOSVolumeSource) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::StorageOSVolumeSource).void).returns(::KubeDSL::DSL::V1::StorageOSVolumeSource) }
     def storage_os_volume_source(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::Sysctl) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::Sysctl).void).returns(::KubeDSL::DSL::V1::Sysctl) }
     def sysctl(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::TCPSocketAction) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::TCPSocketAction).void).returns(::KubeDSL::DSL::V1::TCPSocketAction) }
     def tcp_socket_action(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::Taint) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::Taint).void).returns(::KubeDSL::DSL::V1::Taint) }
     def taint(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::Toleration) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::Toleration).void).returns(::KubeDSL::DSL::V1::Toleration) }
     def toleration(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::TopologySelectorLabelRequirement) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::TopologySelectorLabelRequirement).void).returns(::KubeDSL::DSL::V1::TopologySelectorLabelRequirement) }
     def topology_selector_label_requirement(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::TopologySelectorTerm) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::TopologySelectorTerm).void).returns(::KubeDSL::DSL::V1::TopologySelectorTerm) }
     def topology_selector_term(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::TopologySpreadConstraint) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::TopologySpreadConstraint).void).returns(::KubeDSL::DSL::V1::TopologySpreadConstraint) }
     def topology_spread_constraint(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::TypedLocalObjectReference) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::TypedLocalObjectReference).void).returns(::KubeDSL::DSL::V1::TypedLocalObjectReference) }
     def typed_local_object_reference(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::Volume) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::Volume).void).returns(::KubeDSL::DSL::V1::Volume) }
     def volume(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::VolumeDevice) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::VolumeDevice).void).returns(::KubeDSL::DSL::V1::VolumeDevice) }
     def volume_device(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::VolumeMount) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::VolumeMount).void).returns(::KubeDSL::DSL::V1::VolumeMount) }
     def volume_mount(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::VolumeNodeAffinity) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::VolumeNodeAffinity).void).returns(::KubeDSL::DSL::V1::VolumeNodeAffinity) }
     def volume_node_affinity(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::VolumeProjection) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::VolumeProjection).void).returns(::KubeDSL::DSL::V1::VolumeProjection) }
     def volume_projection(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::VsphereVirtualDiskVolumeSource) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::VsphereVirtualDiskVolumeSource).void).returns(::KubeDSL::DSL::V1::VsphereVirtualDiskVolumeSource) }
     def vsphere_virtual_disk_volume_source(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::WeightedPodAffinityTerm) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::WeightedPodAffinityTerm).void).returns(::KubeDSL::DSL::V1::WeightedPodAffinityTerm) }
     def weighted_pod_affinity_term(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::WindowsSecurityContextOptions) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::WindowsSecurityContextOptions).void).returns(::KubeDSL::DSL::V1::WindowsSecurityContextOptions) }
     def windows_security_context_options(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Discovery::V1::Endpoint) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Discovery::V1::Endpoint).void).returns(::KubeDSL::DSL::Discovery::V1::Endpoint) }
     def endpoint(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Discovery::V1::EndpointConditions) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Discovery::V1::EndpointConditions).void).returns(::KubeDSL::DSL::Discovery::V1::EndpointConditions) }
     def endpoint_conditions(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Discovery::V1::EndpointHints) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Discovery::V1::EndpointHints).void).returns(::KubeDSL::DSL::Discovery::V1::EndpointHints) }
     def endpoint_hints(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Discovery::V1::EndpointPort) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Discovery::V1::EndpointPort).void).returns(::KubeDSL::DSL::Discovery::V1::EndpointPort) }
     def discovery_v1_endpoint_port(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Discovery::V1::EndpointSlice) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Discovery::V1::EndpointSlice).void).returns(::KubeDSL::DSL::Discovery::V1::EndpointSlice) }
     def endpoint_slice(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Discovery::V1::EndpointSliceList) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Discovery::V1::EndpointSliceList).void).returns(::KubeDSL::DSL::Discovery::V1::EndpointSliceList) }
     def endpoint_slice_list(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Discovery::V1::ForZone) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Discovery::V1::ForZone).void).returns(::KubeDSL::DSL::Discovery::V1::ForZone) }
     def for_zone(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Events::V1::Event) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Events::V1::Event).void).returns(::KubeDSL::DSL::Events::V1::Event) }
     def events_v1_event(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Events::V1::EventList) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Events::V1::EventList).void).returns(::KubeDSL::DSL::Events::V1::EventList) }
     def events_v1_event_list(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Events::V1::EventSeries) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Events::V1::EventSeries).void).returns(::KubeDSL::DSL::Events::V1::EventSeries) }
     def events_v1_event_series(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Networking::V1::HTTPIngressPath) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Networking::V1::HTTPIngressPath).void).returns(::KubeDSL::DSL::Networking::V1::HTTPIngressPath) }
     def http_ingress_path(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Networking::V1::HTTPIngressRuleValue) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Networking::V1::HTTPIngressRuleValue).void).returns(::KubeDSL::DSL::Networking::V1::HTTPIngressRuleValue) }
     def http_ingress_rule_value(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Networking::V1::IPBlock) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Networking::V1::IPBlock).void).returns(::KubeDSL::DSL::Networking::V1::IPBlock) }
     def ip_block(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Networking::V1::Ingress) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Networking::V1::Ingress).void).returns(::KubeDSL::DSL::Networking::V1::Ingress) }
     def ingress(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Networking::V1::IngressBackend) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Networking::V1::IngressBackend).void).returns(::KubeDSL::DSL::Networking::V1::IngressBackend) }
     def ingress_backend(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Networking::V1::IngressClass) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Networking::V1::IngressClass).void).returns(::KubeDSL::DSL::Networking::V1::IngressClass) }
     def ingress_class(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Networking::V1::IngressClassList) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Networking::V1::IngressClassList).void).returns(::KubeDSL::DSL::Networking::V1::IngressClassList) }
     def ingress_class_list(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Networking::V1::IngressClassParametersReference) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Networking::V1::IngressClassParametersReference).void).returns(::KubeDSL::DSL::Networking::V1::IngressClassParametersReference) }
     def ingress_class_parameters_reference(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Networking::V1::IngressClassSpec) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Networking::V1::IngressClassSpec).void).returns(::KubeDSL::DSL::Networking::V1::IngressClassSpec) }
     def ingress_class_spec(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Networking::V1::IngressList) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Networking::V1::IngressList).void).returns(::KubeDSL::DSL::Networking::V1::IngressList) }
     def ingress_list(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Networking::V1::IngressRule) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Networking::V1::IngressRule).void).returns(::KubeDSL::DSL::Networking::V1::IngressRule) }
     def ingress_rule(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Networking::V1::IngressServiceBackend) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Networking::V1::IngressServiceBackend).void).returns(::KubeDSL::DSL::Networking::V1::IngressServiceBackend) }
     def ingress_service_backend(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Networking::V1::IngressSpec) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Networking::V1::IngressSpec).void).returns(::KubeDSL::DSL::Networking::V1::IngressSpec) }
     def ingress_spec(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Networking::V1::IngressStatus) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Networking::V1::IngressStatus).void).returns(::KubeDSL::DSL::Networking::V1::IngressStatus) }
     def ingress_status(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Networking::V1::IngressTLS) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Networking::V1::IngressTLS).void).returns(::KubeDSL::DSL::Networking::V1::IngressTLS) }
     def ingress_tls(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Networking::V1::NetworkPolicy) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Networking::V1::NetworkPolicy).void).returns(::KubeDSL::DSL::Networking::V1::NetworkPolicy) }
     def network_policy(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Networking::V1::NetworkPolicyEgressRule) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Networking::V1::NetworkPolicyEgressRule).void).returns(::KubeDSL::DSL::Networking::V1::NetworkPolicyEgressRule) }
     def network_policy_egress_rule(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Networking::V1::NetworkPolicyIngressRule) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Networking::V1::NetworkPolicyIngressRule).void).returns(::KubeDSL::DSL::Networking::V1::NetworkPolicyIngressRule) }
     def network_policy_ingress_rule(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Networking::V1::NetworkPolicyList) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Networking::V1::NetworkPolicyList).void).returns(::KubeDSL::DSL::Networking::V1::NetworkPolicyList) }
     def network_policy_list(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Networking::V1::NetworkPolicyPeer) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Networking::V1::NetworkPolicyPeer).void).returns(::KubeDSL::DSL::Networking::V1::NetworkPolicyPeer) }
     def network_policy_peer(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Networking::V1::NetworkPolicyPort) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Networking::V1::NetworkPolicyPort).void).returns(::KubeDSL::DSL::Networking::V1::NetworkPolicyPort) }
     def network_policy_port(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Networking::V1::NetworkPolicySpec) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Networking::V1::NetworkPolicySpec).void).returns(::KubeDSL::DSL::Networking::V1::NetworkPolicySpec) }
     def network_policy_spec(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Networking::V1::ServiceBackendPort) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Networking::V1::ServiceBackendPort).void).returns(::KubeDSL::DSL::Networking::V1::ServiceBackendPort) }
     def service_backend_port(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Node::V1::Overhead) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Node::V1::Overhead).void).returns(::KubeDSL::DSL::Node::V1::Overhead) }
     def overhead(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Node::V1::RuntimeClass) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Node::V1::RuntimeClass).void).returns(::KubeDSL::DSL::Node::V1::RuntimeClass) }
     def runtime_class(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Node::V1::RuntimeClassList) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Node::V1::RuntimeClassList).void).returns(::KubeDSL::DSL::Node::V1::RuntimeClassList) }
     def runtime_class_list(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Node::V1::Scheduling) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Node::V1::Scheduling).void).returns(::KubeDSL::DSL::Node::V1::Scheduling) }
     def scheduling(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Policy::V1::Eviction) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Policy::V1::Eviction).void).returns(::KubeDSL::DSL::Policy::V1::Eviction) }
     def eviction(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Policy::V1::PodDisruptionBudget) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Policy::V1::PodDisruptionBudget).void).returns(::KubeDSL::DSL::Policy::V1::PodDisruptionBudget) }
     def pod_disruption_budget(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Policy::V1::PodDisruptionBudgetList) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Policy::V1::PodDisruptionBudgetList).void).returns(::KubeDSL::DSL::Policy::V1::PodDisruptionBudgetList) }
     def pod_disruption_budget_list(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Policy::V1::PodDisruptionBudgetSpec) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Policy::V1::PodDisruptionBudgetSpec).void).returns(::KubeDSL::DSL::Policy::V1::PodDisruptionBudgetSpec) }
     def pod_disruption_budget_spec(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Policy::V1::PodDisruptionBudgetStatus) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Policy::V1::PodDisruptionBudgetStatus).void).returns(::KubeDSL::DSL::Policy::V1::PodDisruptionBudgetStatus) }
     def pod_disruption_budget_status(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Rbac::V1::AggregationRule) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Rbac::V1::AggregationRule).void).returns(::KubeDSL::DSL::Rbac::V1::AggregationRule) }
     def aggregation_rule(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Rbac::V1::ClusterRole) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Rbac::V1::ClusterRole).void).returns(::KubeDSL::DSL::Rbac::V1::ClusterRole) }
     def cluster_role(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Rbac::V1::ClusterRoleBinding) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Rbac::V1::ClusterRoleBinding).void).returns(::KubeDSL::DSL::Rbac::V1::ClusterRoleBinding) }
     def cluster_role_binding(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Rbac::V1::ClusterRoleBindingList) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Rbac::V1::ClusterRoleBindingList).void).returns(::KubeDSL::DSL::Rbac::V1::ClusterRoleBindingList) }
     def cluster_role_binding_list(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Rbac::V1::ClusterRoleList) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Rbac::V1::ClusterRoleList).void).returns(::KubeDSL::DSL::Rbac::V1::ClusterRoleList) }
     def cluster_role_list(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Rbac::V1::PolicyRule) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Rbac::V1::PolicyRule).void).returns(::KubeDSL::DSL::Rbac::V1::PolicyRule) }
     def policy_rule(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Rbac::V1::Role) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Rbac::V1::Role).void).returns(::KubeDSL::DSL::Rbac::V1::Role) }
     def role(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Rbac::V1::RoleBinding) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Rbac::V1::RoleBinding).void).returns(::KubeDSL::DSL::Rbac::V1::RoleBinding) }
     def role_binding(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Rbac::V1::RoleBindingList) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Rbac::V1::RoleBindingList).void).returns(::KubeDSL::DSL::Rbac::V1::RoleBindingList) }
     def role_binding_list(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Rbac::V1::RoleList) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Rbac::V1::RoleList).void).returns(::KubeDSL::DSL::Rbac::V1::RoleList) }
     def role_list(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Rbac::V1::RoleRef) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Rbac::V1::RoleRef).void).returns(::KubeDSL::DSL::Rbac::V1::RoleRef) }
     def role_ref(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Rbac::V1::Subject) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Rbac::V1::Subject).void).returns(::KubeDSL::DSL::Rbac::V1::Subject) }
     def subject(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Scheduling::V1::PriorityClass) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Scheduling::V1::PriorityClass).void).returns(::KubeDSL::DSL::Scheduling::V1::PriorityClass) }
     def priority_class(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Scheduling::V1::PriorityClassList) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Scheduling::V1::PriorityClassList).void).returns(::KubeDSL::DSL::Scheduling::V1::PriorityClassList) }
     def priority_class_list(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Storage::V1::CSIDriver) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Storage::V1::CSIDriver).void).returns(::KubeDSL::DSL::Storage::V1::CSIDriver) }
     def csi_driver(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Storage::V1::CSIDriverList) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Storage::V1::CSIDriverList).void).returns(::KubeDSL::DSL::Storage::V1::CSIDriverList) }
     def csi_driver_list(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Storage::V1::CSIDriverSpec) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Storage::V1::CSIDriverSpec).void).returns(::KubeDSL::DSL::Storage::V1::CSIDriverSpec) }
     def csi_driver_spec(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Storage::V1::CSINode) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Storage::V1::CSINode).void).returns(::KubeDSL::DSL::Storage::V1::CSINode) }
     def csi_node(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Storage::V1::CSINodeDriver) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Storage::V1::CSINodeDriver).void).returns(::KubeDSL::DSL::Storage::V1::CSINodeDriver) }
     def csi_node_driver(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Storage::V1::CSINodeList) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Storage::V1::CSINodeList).void).returns(::KubeDSL::DSL::Storage::V1::CSINodeList) }
     def csi_node_list(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Storage::V1::CSINodeSpec) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Storage::V1::CSINodeSpec).void).returns(::KubeDSL::DSL::Storage::V1::CSINodeSpec) }
     def csi_node_spec(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Storage::V1::StorageClass) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Storage::V1::StorageClass).void).returns(::KubeDSL::DSL::Storage::V1::StorageClass) }
     def storage_class(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Storage::V1::StorageClassList) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Storage::V1::StorageClassList).void).returns(::KubeDSL::DSL::Storage::V1::StorageClassList) }
     def storage_class_list(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Storage::V1::TokenRequest) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Storage::V1::TokenRequest).void).returns(::KubeDSL::DSL::Storage::V1::TokenRequest) }
     def storage_v1_token_request(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Storage::V1::VolumeAttachment) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Storage::V1::VolumeAttachment).void).returns(::KubeDSL::DSL::Storage::V1::VolumeAttachment) }
     def volume_attachment(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Storage::V1::VolumeAttachmentList) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Storage::V1::VolumeAttachmentList).void).returns(::KubeDSL::DSL::Storage::V1::VolumeAttachmentList) }
     def volume_attachment_list(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Storage::V1::VolumeAttachmentSource) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Storage::V1::VolumeAttachmentSource).void).returns(::KubeDSL::DSL::Storage::V1::VolumeAttachmentSource) }
     def volume_attachment_source(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Storage::V1::VolumeAttachmentSpec) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Storage::V1::VolumeAttachmentSpec).void).returns(::KubeDSL::DSL::Storage::V1::VolumeAttachmentSpec) }
     def volume_attachment_spec(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Storage::V1::VolumeAttachmentStatus) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Storage::V1::VolumeAttachmentStatus).void).returns(::KubeDSL::DSL::Storage::V1::VolumeAttachmentStatus) }
     def volume_attachment_status(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Storage::V1::VolumeError) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Storage::V1::VolumeError).void).returns(::KubeDSL::DSL::Storage::V1::VolumeError) }
     def volume_error(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Storage::V1::VolumeNodeResources) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Storage::V1::VolumeNodeResources).void).returns(::KubeDSL::DSL::Storage::V1::VolumeNodeResources) }
     def volume_node_resources(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apiextensions::V1::CustomResourceColumnDefinition) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Apiextensions::V1::CustomResourceColumnDefinition).void).returns(::KubeDSL::DSL::Apiextensions::V1::CustomResourceColumnDefinition) }
     def custom_resource_column_definition(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apiextensions::V1::CustomResourceConversion) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Apiextensions::V1::CustomResourceConversion).void).returns(::KubeDSL::DSL::Apiextensions::V1::CustomResourceConversion) }
     def custom_resource_conversion(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinition) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinition).void).returns(::KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinition) }
     def custom_resource_definition(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionCondition) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionCondition).void).returns(::KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionCondition) }
     def custom_resource_definition_condition(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionList) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionList).void).returns(::KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionList) }
     def custom_resource_definition_list(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionNames) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionNames).void).returns(::KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionNames) }
     def custom_resource_definition_names(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionSpec) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionSpec).void).returns(::KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionSpec) }
     def custom_resource_definition_spec(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionStatus) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionStatus).void).returns(::KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionStatus) }
     def custom_resource_definition_status(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionVersion) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionVersion).void).returns(::KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionVersion) }
     def custom_resource_definition_version(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apiextensions::V1::CustomResourceSubresourceScale) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Apiextensions::V1::CustomResourceSubresourceScale).void).returns(::KubeDSL::DSL::Apiextensions::V1::CustomResourceSubresourceScale) }
     def custom_resource_subresource_scale(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apiextensions::V1::CustomResourceSubresources) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Apiextensions::V1::CustomResourceSubresources).void).returns(::KubeDSL::DSL::Apiextensions::V1::CustomResourceSubresources) }
     def custom_resource_subresources(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apiextensions::V1::CustomResourceValidation) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Apiextensions::V1::CustomResourceValidation).void).returns(::KubeDSL::DSL::Apiextensions::V1::CustomResourceValidation) }
     def custom_resource_validation(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apiextensions::V1::ExternalDocumentation) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Apiextensions::V1::ExternalDocumentation).void).returns(::KubeDSL::DSL::Apiextensions::V1::ExternalDocumentation) }
     def external_documentation(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apiextensions::V1::JSONSchemaProps) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Apiextensions::V1::JSONSchemaProps).void).returns(::KubeDSL::DSL::Apiextensions::V1::JSONSchemaProps) }
     def json_schema_props(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apiextensions::V1::ServiceReference) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Apiextensions::V1::ServiceReference).void).returns(::KubeDSL::DSL::Apiextensions::V1::ServiceReference) }
     def apiextensions_v1_service_reference(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apiextensions::V1::ValidationRule) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Apiextensions::V1::ValidationRule).void).returns(::KubeDSL::DSL::Apiextensions::V1::ValidationRule) }
     def validation_rule(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apiextensions::V1::WebhookClientConfig) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Apiextensions::V1::WebhookClientConfig).void).returns(::KubeDSL::DSL::Apiextensions::V1::WebhookClientConfig) }
     def apiextensions_v1_webhook_client_config(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apiextensions::V1::WebhookConversion) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Apiextensions::V1::WebhookConversion).void).returns(::KubeDSL::DSL::Apiextensions::V1::WebhookConversion) }
     def webhook_conversion(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Meta::V1::APIGroup) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Meta::V1::APIGroup).void).returns(::KubeDSL::DSL::Meta::V1::APIGroup) }
     def api_group(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Meta::V1::APIGroupList) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Meta::V1::APIGroupList).void).returns(::KubeDSL::DSL::Meta::V1::APIGroupList) }
     def api_group_list(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Meta::V1::APIResource) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Meta::V1::APIResource).void).returns(::KubeDSL::DSL::Meta::V1::APIResource) }
     def api_resource(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Meta::V1::APIResourceList) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Meta::V1::APIResourceList).void).returns(::KubeDSL::DSL::Meta::V1::APIResourceList) }
     def api_resource_list(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Meta::V1::APIVersions) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Meta::V1::APIVersions).void).returns(::KubeDSL::DSL::Meta::V1::APIVersions) }
     def api_versions(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Meta::V1::Condition) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Meta::V1::Condition).void).returns(::KubeDSL::DSL::Meta::V1::Condition) }
     def condition(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Meta::V1::DeleteOptions) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Meta::V1::DeleteOptions).void).returns(::KubeDSL::DSL::Meta::V1::DeleteOptions) }
     def delete_options(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Meta::V1::GroupVersionForDiscovery) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Meta::V1::GroupVersionForDiscovery).void).returns(::KubeDSL::DSL::Meta::V1::GroupVersionForDiscovery) }
     def group_version_for_discovery(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Meta::V1::LabelSelector) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Meta::V1::LabelSelector).void).returns(::KubeDSL::DSL::Meta::V1::LabelSelector) }
     def label_selector(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Meta::V1::LabelSelectorRequirement) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Meta::V1::LabelSelectorRequirement).void).returns(::KubeDSL::DSL::Meta::V1::LabelSelectorRequirement) }
     def label_selector_requirement(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Meta::V1::ListMeta) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Meta::V1::ListMeta).void).returns(::KubeDSL::DSL::Meta::V1::ListMeta) }
     def list_meta(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Meta::V1::ManagedFieldsEntry) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Meta::V1::ManagedFieldsEntry).void).returns(::KubeDSL::DSL::Meta::V1::ManagedFieldsEntry) }
     def managed_fields_entry(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Meta::V1::ObjectMeta) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Meta::V1::ObjectMeta).void).returns(::KubeDSL::DSL::Meta::V1::ObjectMeta) }
     def object_meta(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Meta::V1::OwnerReference) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Meta::V1::OwnerReference).void).returns(::KubeDSL::DSL::Meta::V1::OwnerReference) }
     def owner_reference(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Meta::V1::Preconditions) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Meta::V1::Preconditions).void).returns(::KubeDSL::DSL::Meta::V1::Preconditions) }
     def preconditions(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Meta::V1::ServerAddressByClientCIDR) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Meta::V1::ServerAddressByClientCIDR).void).returns(::KubeDSL::DSL::Meta::V1::ServerAddressByClientCIDR) }
     def server_address_by_client_cidr(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Meta::V1::Status) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Meta::V1::Status).void).returns(::KubeDSL::DSL::Meta::V1::Status) }
     def status(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Meta::V1::StatusCause) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Meta::V1::StatusCause).void).returns(::KubeDSL::DSL::Meta::V1::StatusCause) }
     def status_cause(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Meta::V1::StatusDetails) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Meta::V1::StatusDetails).void).returns(::KubeDSL::DSL::Meta::V1::StatusDetails) }
     def status_details(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Meta::V1::WatchEvent) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Meta::V1::WatchEvent).void).returns(::KubeDSL::DSL::Meta::V1::WatchEvent) }
     def watch_event(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Pkg::Version::Info) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Pkg::Version::Info).void).returns(::KubeDSL::DSL::Pkg::Version::Info) }
     def info(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apiregistration::V1::APIService) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Apiregistration::V1::APIService).void).returns(::KubeDSL::DSL::Apiregistration::V1::APIService) }
     def api_service(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apiregistration::V1::APIServiceCondition) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Apiregistration::V1::APIServiceCondition).void).returns(::KubeDSL::DSL::Apiregistration::V1::APIServiceCondition) }
     def api_service_condition(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apiregistration::V1::APIServiceList) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Apiregistration::V1::APIServiceList).void).returns(::KubeDSL::DSL::Apiregistration::V1::APIServiceList) }
     def api_service_list(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apiregistration::V1::APIServiceSpec) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Apiregistration::V1::APIServiceSpec).void).returns(::KubeDSL::DSL::Apiregistration::V1::APIServiceSpec) }
     def api_service_spec(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apiregistration::V1::APIServiceStatus) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Apiregistration::V1::APIServiceStatus).void).returns(::KubeDSL::DSL::Apiregistration::V1::APIServiceStatus) }
     def api_service_status(&block); end
 
-    sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apiregistration::V1::ServiceReference) }
+    sig { params(block: T.proc.bind(::KubeDSL::DSL::Apiregistration::V1::ServiceReference).void).returns(::KubeDSL::DSL::Apiregistration::V1::ServiceReference) }
     def apiregistration_v1_service_reference(&block); end
   end
 
@@ -1565,8 +1565,8 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def admission_review_versions(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Admissionregistration::V1::WebhookClientConfig) }
-          def client_config; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Admissionregistration::V1::WebhookClientConfig).void)).returns(KubeDSL::DSL::Admissionregistration::V1::WebhookClientConfig) }
+          def client_config(&block); end
 
           sig { returns(T::Boolean) }
           def client_config_present?; end
@@ -1580,14 +1580,14 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def name(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-          def namespace_selector; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+          def namespace_selector(&block); end
 
           sig { returns(T::Boolean) }
           def namespace_selector_present?; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-          def object_selector; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+          def object_selector(&block); end
 
           sig { returns(T::Boolean) }
           def object_selector_present?; end
@@ -1616,8 +1616,8 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -1640,8 +1640,8 @@ module KubeDSL
           sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::Admissionregistration::V1::MutatingWebhookConfiguration))).returns(T::Array[KubeDSL::DSL::Admissionregistration::V1::MutatingWebhookConfiguration]) }
           def items(elem_name = nil, &block); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -1712,8 +1712,8 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def admission_review_versions(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Admissionregistration::V1::WebhookClientConfig) }
-          def client_config; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Admissionregistration::V1::WebhookClientConfig).void)).returns(KubeDSL::DSL::Admissionregistration::V1::WebhookClientConfig) }
+          def client_config(&block); end
 
           sig { returns(T::Boolean) }
           def client_config_present?; end
@@ -1727,14 +1727,14 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def name(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-          def namespace_selector; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+          def namespace_selector(&block); end
 
           sig { returns(T::Boolean) }
           def namespace_selector_present?; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-          def object_selector; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+          def object_selector(&block); end
 
           sig { returns(T::Boolean) }
           def object_selector_present?; end
@@ -1760,8 +1760,8 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -1784,8 +1784,8 @@ module KubeDSL
           sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::Admissionregistration::V1::ValidatingWebhookConfiguration))).returns(T::Array[KubeDSL::DSL::Admissionregistration::V1::ValidatingWebhookConfiguration]) }
           def items(elem_name = nil, &block); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -1805,8 +1805,8 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def ca_bundle(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Admissionregistration::V1::ServiceReference) }
-          def service; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Admissionregistration::V1::ServiceReference).void)).returns(KubeDSL::DSL::Admissionregistration::V1::ServiceReference) }
+          def service(&block); end
 
           sig { returns(T::Boolean) }
           def service_present?; end
@@ -1863,8 +1863,8 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def strategy(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Apiextensions::V1::WebhookConversion) }
-          def webhook; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apiextensions::V1::WebhookConversion).void)).returns(KubeDSL::DSL::Apiextensions::V1::WebhookConversion) }
+          def webhook(&block); end
 
           sig { returns(T::Boolean) }
           def webhook_present?; end
@@ -1881,20 +1881,20 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          sig { returns(KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionSpec) }
-          def spec; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionSpec).void)).returns(KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionSpec) }
+          def spec(&block); end
 
           sig { returns(T::Boolean) }
           def spec_present?; end
 
-          sig { returns(KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionStatus) }
-          def status; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionStatus).void)).returns(KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionStatus) }
+          def status(&block); end
 
           sig { returns(T::Boolean) }
           def status_present?; end
@@ -1941,8 +1941,8 @@ module KubeDSL
           sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinition))).returns(T::Array[KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinition]) }
           def items(elem_name = nil, &block); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -1989,8 +1989,8 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Apiextensions::V1::CustomResourceConversion) }
-          def conversion; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apiextensions::V1::CustomResourceConversion).void)).returns(KubeDSL::DSL::Apiextensions::V1::CustomResourceConversion) }
+          def conversion(&block); end
 
           sig { returns(T::Boolean) }
           def conversion_present?; end
@@ -1998,8 +1998,8 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def group(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionNames) }
-          def names; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionNames).void)).returns(KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionNames) }
+          def names(&block); end
 
           sig { returns(T::Boolean) }
           def names_present?; end
@@ -2025,8 +2025,8 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionNames) }
-          def accepted_names; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionNames).void)).returns(KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionNames) }
+          def accepted_names(&block); end
 
           sig { returns(T::Boolean) }
           def accepted_names_present?; end
@@ -2061,8 +2061,8 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def name(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Apiextensions::V1::CustomResourceValidation) }
-          def schema; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apiextensions::V1::CustomResourceValidation).void)).returns(KubeDSL::DSL::Apiextensions::V1::CustomResourceValidation) }
+          def schema(&block); end
 
           sig { returns(T::Boolean) }
           def schema_present?; end
@@ -2073,8 +2073,8 @@ module KubeDSL
           sig { params(val: T.nilable(T::Boolean)).returns(T::Boolean) }
           def storage(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Apiextensions::V1::CustomResourceSubresources) }
-          def subresources; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apiextensions::V1::CustomResourceSubresources).void)).returns(KubeDSL::DSL::Apiextensions::V1::CustomResourceSubresources) }
+          def subresources(&block); end
 
           sig { returns(T::Boolean) }
           def subresources_present?; end
@@ -2112,8 +2112,8 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Apiextensions::V1::CustomResourceSubresourceScale) }
-          def scale; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apiextensions::V1::CustomResourceSubresourceScale).void)).returns(KubeDSL::DSL::Apiextensions::V1::CustomResourceSubresourceScale) }
+          def scale(&block); end
 
           sig { returns(T::Boolean) }
           def scale_present?; end
@@ -2133,8 +2133,8 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Apiextensions::V1::JSONSchemaProps) }
-          def open_apiv3_schema; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apiextensions::V1::JSONSchemaProps).void)).returns(KubeDSL::DSL::Apiextensions::V1::JSONSchemaProps) }
+          def open_apiv3_schema(&block); end
 
           sig { returns(T::Boolean) }
           def open_apiv3_schema_present?; end
@@ -2203,10 +2203,10 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def default(val = nil); end
 
-          sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+          sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
           def definitions(&block); end
 
-          sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+          sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
           def dependencies(&block); end
 
           sig { params(val: T.nilable(String)).returns(String) }
@@ -2224,8 +2224,8 @@ module KubeDSL
           sig { params(val: T.nilable(T::Boolean)).returns(T::Boolean) }
           def exclusive_minimum(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Apiextensions::V1::ExternalDocumentation) }
-          def external_docs; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apiextensions::V1::ExternalDocumentation).void)).returns(KubeDSL::DSL::Apiextensions::V1::ExternalDocumentation) }
+          def external_docs(&block); end
 
           sig { returns(T::Boolean) }
           def external_docs_present?; end
@@ -2266,8 +2266,8 @@ module KubeDSL
           sig { params(val: T.nilable(Integer)).returns(Integer) }
           def multiple_of(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Apiextensions::V1::JSONSchemaProps) }
-          def not_field; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apiextensions::V1::JSONSchemaProps).void)).returns(KubeDSL::DSL::Apiextensions::V1::JSONSchemaProps) }
+          def not_field(&block); end
 
           sig { returns(T::Boolean) }
           def not_field_present?; end
@@ -2281,10 +2281,10 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def pattern(val = nil); end
 
-          sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+          sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
           def pattern_properties(&block); end
 
-          sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+          sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
           def properties(&block); end
 
           sig { params(val: T.nilable(String)).returns(String) }
@@ -2377,8 +2377,8 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def ca_bundle(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Apiextensions::V1::ServiceReference) }
-          def service; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apiextensions::V1::ServiceReference).void)).returns(KubeDSL::DSL::Apiextensions::V1::ServiceReference) }
+          def service(&block); end
 
           sig { returns(T::Boolean) }
           def service_present?; end
@@ -2398,8 +2398,8 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Apiextensions::V1::WebhookClientConfig) }
-          def client_config; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apiextensions::V1::WebhookClientConfig).void)).returns(KubeDSL::DSL::Apiextensions::V1::WebhookClientConfig) }
+          def client_config(&block); end
 
           sig { returns(T::Boolean) }
           def client_config_present?; end
@@ -2423,20 +2423,20 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          sig { returns(KubeDSL::DSL::Apiregistration::V1::APIServiceSpec) }
-          def spec; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apiregistration::V1::APIServiceSpec).void)).returns(KubeDSL::DSL::Apiregistration::V1::APIServiceSpec) }
+          def spec(&block); end
 
           sig { returns(T::Boolean) }
           def spec_present?; end
 
-          sig { returns(KubeDSL::DSL::Apiregistration::V1::APIServiceStatus) }
-          def status; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apiregistration::V1::APIServiceStatus).void)).returns(KubeDSL::DSL::Apiregistration::V1::APIServiceStatus) }
+          def status(&block); end
 
           sig { returns(T::Boolean) }
           def status_present?; end
@@ -2483,8 +2483,8 @@ module KubeDSL
           sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::Apiregistration::V1::APIService))).returns(T::Array[KubeDSL::DSL::Apiregistration::V1::APIService]) }
           def items(elem_name = nil, &block); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -2513,8 +2513,8 @@ module KubeDSL
           sig { params(val: T.nilable(T::Boolean)).returns(T::Boolean) }
           def insecure_skip_tls_verify(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Apiregistration::V1::ServiceReference) }
-          def service; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apiregistration::V1::ServiceReference).void)).returns(KubeDSL::DSL::Apiregistration::V1::ServiceReference) }
+          def service(&block); end
 
           sig { returns(T::Boolean) }
           def service_present?; end
@@ -2598,8 +2598,8 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -2607,8 +2607,8 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def spec(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Apiserverinternal::V1alpha1::StorageVersionStatus) }
-          def status; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apiserverinternal::V1alpha1::StorageVersionStatus).void)).returns(KubeDSL::DSL::Apiserverinternal::V1alpha1::StorageVersionStatus) }
+          def status(&block); end
 
           sig { returns(T::Boolean) }
           def status_present?; end
@@ -2658,8 +2658,8 @@ module KubeDSL
           sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::Apiserverinternal::V1alpha1::StorageVersion))).returns(T::Array[KubeDSL::DSL::Apiserverinternal::V1alpha1::StorageVersion]) }
           def items(elem_name = nil, &block); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -2704,8 +2704,8 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def data(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -2728,8 +2728,8 @@ module KubeDSL
           sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::Apps::V1::ControllerRevision))).returns(T::Array[KubeDSL::DSL::Apps::V1::ControllerRevision]) }
           def items(elem_name = nil, &block); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -2746,20 +2746,20 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          sig { returns(KubeDSL::DSL::Apps::V1::DaemonSetSpec) }
-          def spec; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apps::V1::DaemonSetSpec).void)).returns(KubeDSL::DSL::Apps::V1::DaemonSetSpec) }
+          def spec(&block); end
 
           sig { returns(T::Boolean) }
           def spec_present?; end
 
-          sig { returns(KubeDSL::DSL::Apps::V1::DaemonSetStatus) }
-          def status; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apps::V1::DaemonSetStatus).void)).returns(KubeDSL::DSL::Apps::V1::DaemonSetStatus) }
+          def status(&block); end
 
           sig { returns(T::Boolean) }
           def status_present?; end
@@ -2806,8 +2806,8 @@ module KubeDSL
           sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::Apps::V1::DaemonSet))).returns(T::Array[KubeDSL::DSL::Apps::V1::DaemonSet]) }
           def items(elem_name = nil, &block); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -2830,20 +2830,20 @@ module KubeDSL
           sig { params(val: T.nilable(Integer)).returns(Integer) }
           def revision_history_limit(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-          def selector; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+          def selector(&block); end
 
           sig { returns(T::Boolean) }
           def selector_present?; end
 
-          sig { returns(KubeDSL::DSL::V1::PodTemplateSpec) }
-          def template; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PodTemplateSpec).void)).returns(KubeDSL::DSL::V1::PodTemplateSpec) }
+          def template(&block); end
 
           sig { returns(T::Boolean) }
           def template_present?; end
 
-          sig { returns(KubeDSL::DSL::Apps::V1::DaemonSetUpdateStrategy) }
-          def update_strategy; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apps::V1::DaemonSetUpdateStrategy).void)).returns(KubeDSL::DSL::Apps::V1::DaemonSetUpdateStrategy) }
+          def update_strategy(&block); end
 
           sig { returns(T::Boolean) }
           def update_strategy_present?; end
@@ -2902,8 +2902,8 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Apps::V1::RollingUpdateDaemonSet) }
-          def rolling_update; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apps::V1::RollingUpdateDaemonSet).void)).returns(KubeDSL::DSL::Apps::V1::RollingUpdateDaemonSet) }
+          def rolling_update(&block); end
 
           sig { returns(T::Boolean) }
           def rolling_update_present?; end
@@ -2923,20 +2923,20 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          sig { returns(KubeDSL::DSL::Apps::V1::DeploymentSpec) }
-          def spec; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apps::V1::DeploymentSpec).void)).returns(KubeDSL::DSL::Apps::V1::DeploymentSpec) }
+          def spec(&block); end
 
           sig { returns(T::Boolean) }
           def spec_present?; end
 
-          sig { returns(KubeDSL::DSL::Apps::V1::DeploymentStatus) }
-          def status; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apps::V1::DeploymentStatus).void)).returns(KubeDSL::DSL::Apps::V1::DeploymentStatus) }
+          def status(&block); end
 
           sig { returns(T::Boolean) }
           def status_present?; end
@@ -2986,8 +2986,8 @@ module KubeDSL
           sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::Apps::V1::Deployment))).returns(T::Array[KubeDSL::DSL::Apps::V1::Deployment]) }
           def items(elem_name = nil, &block); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -3019,20 +3019,20 @@ module KubeDSL
           sig { params(val: T.nilable(Integer)).returns(Integer) }
           def revision_history_limit(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-          def selector; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+          def selector(&block); end
 
           sig { returns(T::Boolean) }
           def selector_present?; end
 
-          sig { returns(KubeDSL::DSL::Apps::V1::DeploymentStrategy) }
-          def strategy; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apps::V1::DeploymentStrategy).void)).returns(KubeDSL::DSL::Apps::V1::DeploymentStrategy) }
+          def strategy(&block); end
 
           sig { returns(T::Boolean) }
           def strategy_present?; end
 
-          sig { returns(KubeDSL::DSL::V1::PodTemplateSpec) }
-          def template; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PodTemplateSpec).void)).returns(KubeDSL::DSL::V1::PodTemplateSpec) }
+          def template(&block); end
 
           sig { returns(T::Boolean) }
           def template_present?; end
@@ -3085,8 +3085,8 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Apps::V1::RollingUpdateDeployment) }
-          def rolling_update; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apps::V1::RollingUpdateDeployment).void)).returns(KubeDSL::DSL::Apps::V1::RollingUpdateDeployment) }
+          def rolling_update(&block); end
 
           sig { returns(T::Boolean) }
           def rolling_update_present?; end
@@ -3106,20 +3106,20 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          sig { returns(KubeDSL::DSL::Apps::V1::ReplicaSetSpec) }
-          def spec; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apps::V1::ReplicaSetSpec).void)).returns(KubeDSL::DSL::Apps::V1::ReplicaSetSpec) }
+          def spec(&block); end
 
           sig { returns(T::Boolean) }
           def spec_present?; end
 
-          sig { returns(KubeDSL::DSL::Apps::V1::ReplicaSetStatus) }
-          def status; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apps::V1::ReplicaSetStatus).void)).returns(KubeDSL::DSL::Apps::V1::ReplicaSetStatus) }
+          def status(&block); end
 
           sig { returns(T::Boolean) }
           def status_present?; end
@@ -3166,8 +3166,8 @@ module KubeDSL
           sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::Apps::V1::ReplicaSet))).returns(T::Array[KubeDSL::DSL::Apps::V1::ReplicaSet]) }
           def items(elem_name = nil, &block); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -3190,14 +3190,14 @@ module KubeDSL
           sig { params(val: T.nilable(Integer)).returns(Integer) }
           def replicas(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-          def selector; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+          def selector(&block); end
 
           sig { returns(T::Boolean) }
           def selector_present?; end
 
-          sig { returns(KubeDSL::DSL::V1::PodTemplateSpec) }
-          def template; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PodTemplateSpec).void)).returns(KubeDSL::DSL::V1::PodTemplateSpec) }
+          def template(&block); end
 
           sig { returns(T::Boolean) }
           def template_present?; end
@@ -3295,20 +3295,20 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          sig { returns(KubeDSL::DSL::Apps::V1::StatefulSetSpec) }
-          def spec; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apps::V1::StatefulSetSpec).void)).returns(KubeDSL::DSL::Apps::V1::StatefulSetSpec) }
+          def spec(&block); end
 
           sig { returns(T::Boolean) }
           def spec_present?; end
 
-          sig { returns(KubeDSL::DSL::Apps::V1::StatefulSetStatus) }
-          def status; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apps::V1::StatefulSetStatus).void)).returns(KubeDSL::DSL::Apps::V1::StatefulSetStatus) }
+          def status(&block); end
 
           sig { returns(T::Boolean) }
           def status_present?; end
@@ -3355,8 +3355,8 @@ module KubeDSL
           sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::Apps::V1::StatefulSet))).returns(T::Array[KubeDSL::DSL::Apps::V1::StatefulSet]) }
           def items(elem_name = nil, &block); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -3394,8 +3394,8 @@ module KubeDSL
           sig { params(val: T.nilable(Integer)).returns(Integer) }
           def min_ready_seconds(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Apps::V1::StatefulSetPersistentVolumeClaimRetentionPolicy) }
-          def persistent_volume_claim_retention_policy; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apps::V1::StatefulSetPersistentVolumeClaimRetentionPolicy).void)).returns(KubeDSL::DSL::Apps::V1::StatefulSetPersistentVolumeClaimRetentionPolicy) }
+          def persistent_volume_claim_retention_policy(&block); end
 
           sig { returns(T::Boolean) }
           def persistent_volume_claim_retention_policy_present?; end
@@ -3409,8 +3409,8 @@ module KubeDSL
           sig { params(val: T.nilable(Integer)).returns(Integer) }
           def revision_history_limit(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-          def selector; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+          def selector(&block); end
 
           sig { returns(T::Boolean) }
           def selector_present?; end
@@ -3418,14 +3418,14 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def service_name(val = nil); end
 
-          sig { returns(KubeDSL::DSL::V1::PodTemplateSpec) }
-          def template; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PodTemplateSpec).void)).returns(KubeDSL::DSL::V1::PodTemplateSpec) }
+          def template(&block); end
 
           sig { returns(T::Boolean) }
           def template_present?; end
 
-          sig { returns(KubeDSL::DSL::Apps::V1::StatefulSetUpdateStrategy) }
-          def update_strategy; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apps::V1::StatefulSetUpdateStrategy).void)).returns(KubeDSL::DSL::Apps::V1::StatefulSetUpdateStrategy) }
+          def update_strategy(&block); end
 
           sig { returns(T::Boolean) }
           def update_strategy_present?; end
@@ -3487,8 +3487,8 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Apps::V1::RollingUpdateStatefulSetStrategy) }
-          def rolling_update; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apps::V1::RollingUpdateStatefulSetStrategy).void)).returns(KubeDSL::DSL::Apps::V1::RollingUpdateStatefulSetStrategy) }
+          def rolling_update(&block); end
 
           sig { returns(T::Boolean) }
           def rolling_update_present?; end
@@ -3536,20 +3536,20 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          sig { returns(KubeDSL::DSL::Authentication::V1::TokenRequestSpec) }
-          def spec; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Authentication::V1::TokenRequestSpec).void)).returns(KubeDSL::DSL::Authentication::V1::TokenRequestSpec) }
+          def spec(&block); end
 
           sig { returns(T::Boolean) }
           def spec_present?; end
 
-          sig { returns(KubeDSL::DSL::Authentication::V1::TokenRequestStatus) }
-          def status; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Authentication::V1::TokenRequestStatus).void)).returns(KubeDSL::DSL::Authentication::V1::TokenRequestStatus) }
+          def status(&block); end
 
           sig { returns(T::Boolean) }
           def status_present?; end
@@ -3569,8 +3569,8 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def audiences(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Authentication::V1::BoundObjectReference) }
-          def bound_object_ref; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Authentication::V1::BoundObjectReference).void)).returns(KubeDSL::DSL::Authentication::V1::BoundObjectReference) }
+          def bound_object_ref(&block); end
 
           sig { returns(T::Boolean) }
           def bound_object_ref_present?; end
@@ -3608,20 +3608,20 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          sig { returns(KubeDSL::DSL::Authentication::V1::TokenReviewSpec) }
-          def spec; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Authentication::V1::TokenReviewSpec).void)).returns(KubeDSL::DSL::Authentication::V1::TokenReviewSpec) }
+          def spec(&block); end
 
           sig { returns(T::Boolean) }
           def spec_present?; end
 
-          sig { returns(KubeDSL::DSL::Authentication::V1::TokenReviewStatus) }
-          def status; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Authentication::V1::TokenReviewStatus).void)).returns(KubeDSL::DSL::Authentication::V1::TokenReviewStatus) }
+          def status(&block); end
 
           sig { returns(T::Boolean) }
           def status_present?; end
@@ -3665,8 +3665,8 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def error(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Authentication::V1::UserInfo) }
-          def user; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Authentication::V1::UserInfo).void)).returns(KubeDSL::DSL::Authentication::V1::UserInfo) }
+          def user(&block); end
 
           sig { returns(T::Boolean) }
           def user_present?; end
@@ -3683,7 +3683,7 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+          sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
           def extra(&block); end
 
           sig { params(val: T.nilable(String)).returns(String) }
@@ -3711,20 +3711,20 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          sig { returns(KubeDSL::DSL::Authorization::V1::SubjectAccessReviewSpec) }
-          def spec; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Authorization::V1::SubjectAccessReviewSpec).void)).returns(KubeDSL::DSL::Authorization::V1::SubjectAccessReviewSpec) }
+          def spec(&block); end
 
           sig { returns(T::Boolean) }
           def spec_present?; end
 
-          sig { returns(KubeDSL::DSL::Authorization::V1::SubjectAccessReviewStatus) }
-          def status; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Authorization::V1::SubjectAccessReviewStatus).void)).returns(KubeDSL::DSL::Authorization::V1::SubjectAccessReviewStatus) }
+          def status(&block); end
 
           sig { returns(T::Boolean) }
           def status_present?; end
@@ -3834,20 +3834,20 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          sig { returns(KubeDSL::DSL::Authorization::V1::SelfSubjectAccessReviewSpec) }
-          def spec; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Authorization::V1::SelfSubjectAccessReviewSpec).void)).returns(KubeDSL::DSL::Authorization::V1::SelfSubjectAccessReviewSpec) }
+          def spec(&block); end
 
           sig { returns(T::Boolean) }
           def spec_present?; end
 
-          sig { returns(KubeDSL::DSL::Authorization::V1::SubjectAccessReviewStatus) }
-          def status; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Authorization::V1::SubjectAccessReviewStatus).void)).returns(KubeDSL::DSL::Authorization::V1::SubjectAccessReviewStatus) }
+          def status(&block); end
 
           sig { returns(T::Boolean) }
           def status_present?; end
@@ -3864,14 +3864,14 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Authorization::V1::NonResourceAttributes) }
-          def non_resource_attributes; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Authorization::V1::NonResourceAttributes).void)).returns(KubeDSL::DSL::Authorization::V1::NonResourceAttributes) }
+          def non_resource_attributes(&block); end
 
           sig { returns(T::Boolean) }
           def non_resource_attributes_present?; end
 
-          sig { returns(KubeDSL::DSL::Authorization::V1::ResourceAttributes) }
-          def resource_attributes; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Authorization::V1::ResourceAttributes).void)).returns(KubeDSL::DSL::Authorization::V1::ResourceAttributes) }
+          def resource_attributes(&block); end
 
           sig { returns(T::Boolean) }
           def resource_attributes_present?; end
@@ -3888,20 +3888,20 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          sig { returns(KubeDSL::DSL::Authorization::V1::SelfSubjectRulesReviewSpec) }
-          def spec; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Authorization::V1::SelfSubjectRulesReviewSpec).void)).returns(KubeDSL::DSL::Authorization::V1::SelfSubjectRulesReviewSpec) }
+          def spec(&block); end
 
           sig { returns(T::Boolean) }
           def spec_present?; end
 
-          sig { returns(KubeDSL::DSL::Authorization::V1::SubjectRulesReviewStatus) }
-          def status; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Authorization::V1::SubjectRulesReviewStatus).void)).returns(KubeDSL::DSL::Authorization::V1::SubjectRulesReviewStatus) }
+          def status(&block); end
 
           sig { returns(T::Boolean) }
           def status_present?; end
@@ -3933,20 +3933,20 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          sig { returns(KubeDSL::DSL::Authorization::V1::SubjectAccessReviewSpec) }
-          def spec; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Authorization::V1::SubjectAccessReviewSpec).void)).returns(KubeDSL::DSL::Authorization::V1::SubjectAccessReviewSpec) }
+          def spec(&block); end
 
           sig { returns(T::Boolean) }
           def spec_present?; end
 
-          sig { returns(KubeDSL::DSL::Authorization::V1::SubjectAccessReviewStatus) }
-          def status; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Authorization::V1::SubjectAccessReviewStatus).void)).returns(KubeDSL::DSL::Authorization::V1::SubjectAccessReviewStatus) }
+          def status(&block); end
 
           sig { returns(T::Boolean) }
           def status_present?; end
@@ -3963,20 +3963,20 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+          sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
           def extra(&block); end
 
           sig { params(val: T.nilable(String)).returns(String) }
           def groups(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Authorization::V1::NonResourceAttributes) }
-          def non_resource_attributes; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Authorization::V1::NonResourceAttributes).void)).returns(KubeDSL::DSL::Authorization::V1::NonResourceAttributes) }
+          def non_resource_attributes(&block); end
 
           sig { returns(T::Boolean) }
           def non_resource_attributes_present?; end
 
-          sig { returns(KubeDSL::DSL::Authorization::V1::ResourceAttributes) }
-          def resource_attributes; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Authorization::V1::ResourceAttributes).void)).returns(KubeDSL::DSL::Authorization::V1::ResourceAttributes) }
+          def resource_attributes(&block); end
 
           sig { returns(T::Boolean) }
           def resource_attributes_present?; end
@@ -4072,20 +4072,20 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V1::HorizontalPodAutoscalerSpec) }
-          def spec; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V1::HorizontalPodAutoscalerSpec).void)).returns(KubeDSL::DSL::Autoscaling::V1::HorizontalPodAutoscalerSpec) }
+          def spec(&block); end
 
           sig { returns(T::Boolean) }
           def spec_present?; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V1::HorizontalPodAutoscalerStatus) }
-          def status; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V1::HorizontalPodAutoscalerStatus).void)).returns(KubeDSL::DSL::Autoscaling::V1::HorizontalPodAutoscalerStatus) }
+          def status(&block); end
 
           sig { returns(T::Boolean) }
           def status_present?; end
@@ -4105,8 +4105,8 @@ module KubeDSL
           sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::Autoscaling::V1::HorizontalPodAutoscaler))).returns(T::Array[KubeDSL::DSL::Autoscaling::V1::HorizontalPodAutoscaler]) }
           def items(elem_name = nil, &block); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -4129,8 +4129,8 @@ module KubeDSL
           sig { params(val: T.nilable(Integer)).returns(Integer) }
           def min_replicas(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V1::CrossVersionObjectReference) }
-          def scale_target_ref; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V1::CrossVersionObjectReference).void)).returns(KubeDSL::DSL::Autoscaling::V1::CrossVersionObjectReference) }
+          def scale_target_ref(&block); end
 
           sig { returns(T::Boolean) }
           def scale_target_ref_present?; end
@@ -4177,20 +4177,20 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V1::ScaleSpec) }
-          def spec; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V1::ScaleSpec).void)).returns(KubeDSL::DSL::Autoscaling::V1::ScaleSpec) }
+          def spec(&block); end
 
           sig { returns(T::Boolean) }
           def spec_present?; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V1::ScaleStatus) }
-          def status; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V1::ScaleStatus).void)).returns(KubeDSL::DSL::Autoscaling::V1::ScaleStatus) }
+          def status(&block); end
 
           sig { returns(T::Boolean) }
           def status_present?; end
@@ -4248,8 +4248,8 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def name(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2::MetricTarget) }
-          def target; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::MetricTarget).void)).returns(KubeDSL::DSL::Autoscaling::V2::MetricTarget) }
+          def target(&block); end
 
           sig { returns(T::Boolean) }
           def target_present?; end
@@ -4269,8 +4269,8 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def container(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2::MetricValueStatus) }
-          def current; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::MetricValueStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2::MetricValueStatus) }
+          def current(&block); end
 
           sig { returns(T::Boolean) }
           def current_present?; end
@@ -4311,14 +4311,14 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2::MetricIdentifier) }
-          def metric; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::MetricIdentifier).void)).returns(KubeDSL::DSL::Autoscaling::V2::MetricIdentifier) }
+          def metric(&block); end
 
           sig { returns(T::Boolean) }
           def metric_present?; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2::MetricTarget) }
-          def target; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::MetricTarget).void)).returns(KubeDSL::DSL::Autoscaling::V2::MetricTarget) }
+          def target(&block); end
 
           sig { returns(T::Boolean) }
           def target_present?; end
@@ -4335,14 +4335,14 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2::MetricValueStatus) }
-          def current; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::MetricValueStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2::MetricValueStatus) }
+          def current(&block); end
 
           sig { returns(T::Boolean) }
           def current_present?; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2::MetricIdentifier) }
-          def metric; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::MetricIdentifier).void)).returns(KubeDSL::DSL::Autoscaling::V2::MetricIdentifier) }
+          def metric(&block); end
 
           sig { returns(T::Boolean) }
           def metric_present?; end
@@ -4359,20 +4359,20 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscalerSpec) }
-          def spec; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscalerSpec).void)).returns(KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscalerSpec) }
+          def spec(&block); end
 
           sig { returns(T::Boolean) }
           def spec_present?; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscalerStatus) }
-          def status; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscalerStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscalerStatus) }
+          def status(&block); end
 
           sig { returns(T::Boolean) }
           def status_present?; end
@@ -4389,14 +4389,14 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2::HPAScalingRules) }
-          def scale_down; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::HPAScalingRules).void)).returns(KubeDSL::DSL::Autoscaling::V2::HPAScalingRules) }
+          def scale_down(&block); end
 
           sig { returns(T::Boolean) }
           def scale_down_present?; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2::HPAScalingRules) }
-          def scale_up; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::HPAScalingRules).void)).returns(KubeDSL::DSL::Autoscaling::V2::HPAScalingRules) }
+          def scale_up(&block); end
 
           sig { returns(T::Boolean) }
           def scale_up_present?; end
@@ -4443,8 +4443,8 @@ module KubeDSL
           sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscaler))).returns(T::Array[KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscaler]) }
           def items(elem_name = nil, &block); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -4461,8 +4461,8 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscalerBehavior) }
-          def behavior; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscalerBehavior).void)).returns(KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscalerBehavior) }
+          def behavior(&block); end
 
           sig { returns(T::Boolean) }
           def behavior_present?; end
@@ -4476,8 +4476,8 @@ module KubeDSL
           sig { params(val: T.nilable(Integer)).returns(Integer) }
           def min_replicas(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2::CrossVersionObjectReference) }
-          def scale_target_ref; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::CrossVersionObjectReference).void)).returns(KubeDSL::DSL::Autoscaling::V2::CrossVersionObjectReference) }
+          def scale_target_ref(&block); end
 
           sig { returns(T::Boolean) }
           def scale_target_ref_present?; end
@@ -4569,8 +4569,8 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def name(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-          def selector; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+          def selector(&block); end
 
           sig { returns(T::Boolean) }
           def selector_present?; end
@@ -4587,32 +4587,32 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2::ContainerResourceMetricSource) }
-          def container_resource; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::ContainerResourceMetricSource).void)).returns(KubeDSL::DSL::Autoscaling::V2::ContainerResourceMetricSource) }
+          def container_resource(&block); end
 
           sig { returns(T::Boolean) }
           def container_resource_present?; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2::ExternalMetricSource) }
-          def external; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::ExternalMetricSource).void)).returns(KubeDSL::DSL::Autoscaling::V2::ExternalMetricSource) }
+          def external(&block); end
 
           sig { returns(T::Boolean) }
           def external_present?; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2::ObjectMetricSource) }
-          def object; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::ObjectMetricSource).void)).returns(KubeDSL::DSL::Autoscaling::V2::ObjectMetricSource) }
+          def object(&block); end
 
           sig { returns(T::Boolean) }
           def object_present?; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2::PodsMetricSource) }
-          def pods; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::PodsMetricSource).void)).returns(KubeDSL::DSL::Autoscaling::V2::PodsMetricSource) }
+          def pods(&block); end
 
           sig { returns(T::Boolean) }
           def pods_present?; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2::ResourceMetricSource) }
-          def resource; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::ResourceMetricSource).void)).returns(KubeDSL::DSL::Autoscaling::V2::ResourceMetricSource) }
+          def resource(&block); end
 
           sig { returns(T::Boolean) }
           def resource_present?; end
@@ -4632,32 +4632,32 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2::ContainerResourceMetricStatus) }
-          def container_resource; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::ContainerResourceMetricStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2::ContainerResourceMetricStatus) }
+          def container_resource(&block); end
 
           sig { returns(T::Boolean) }
           def container_resource_present?; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2::ExternalMetricStatus) }
-          def external; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::ExternalMetricStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2::ExternalMetricStatus) }
+          def external(&block); end
 
           sig { returns(T::Boolean) }
           def external_present?; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2::ObjectMetricStatus) }
-          def object; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::ObjectMetricStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2::ObjectMetricStatus) }
+          def object(&block); end
 
           sig { returns(T::Boolean) }
           def object_present?; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2::PodsMetricStatus) }
-          def pods; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::PodsMetricStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2::PodsMetricStatus) }
+          def pods(&block); end
 
           sig { returns(T::Boolean) }
           def pods_present?; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2::ResourceMetricStatus) }
-          def resource; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::ResourceMetricStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2::ResourceMetricStatus) }
+          def resource(&block); end
 
           sig { returns(T::Boolean) }
           def resource_present?; end
@@ -4722,20 +4722,20 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2::CrossVersionObjectReference) }
-          def described_object; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::CrossVersionObjectReference).void)).returns(KubeDSL::DSL::Autoscaling::V2::CrossVersionObjectReference) }
+          def described_object(&block); end
 
           sig { returns(T::Boolean) }
           def described_object_present?; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2::MetricIdentifier) }
-          def metric; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::MetricIdentifier).void)).returns(KubeDSL::DSL::Autoscaling::V2::MetricIdentifier) }
+          def metric(&block); end
 
           sig { returns(T::Boolean) }
           def metric_present?; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2::MetricTarget) }
-          def target; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::MetricTarget).void)).returns(KubeDSL::DSL::Autoscaling::V2::MetricTarget) }
+          def target(&block); end
 
           sig { returns(T::Boolean) }
           def target_present?; end
@@ -4752,20 +4752,20 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2::MetricValueStatus) }
-          def current; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::MetricValueStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2::MetricValueStatus) }
+          def current(&block); end
 
           sig { returns(T::Boolean) }
           def current_present?; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2::CrossVersionObjectReference) }
-          def described_object; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::CrossVersionObjectReference).void)).returns(KubeDSL::DSL::Autoscaling::V2::CrossVersionObjectReference) }
+          def described_object(&block); end
 
           sig { returns(T::Boolean) }
           def described_object_present?; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2::MetricIdentifier) }
-          def metric; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::MetricIdentifier).void)).returns(KubeDSL::DSL::Autoscaling::V2::MetricIdentifier) }
+          def metric(&block); end
 
           sig { returns(T::Boolean) }
           def metric_present?; end
@@ -4782,14 +4782,14 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2::MetricIdentifier) }
-          def metric; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::MetricIdentifier).void)).returns(KubeDSL::DSL::Autoscaling::V2::MetricIdentifier) }
+          def metric(&block); end
 
           sig { returns(T::Boolean) }
           def metric_present?; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2::MetricTarget) }
-          def target; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::MetricTarget).void)).returns(KubeDSL::DSL::Autoscaling::V2::MetricTarget) }
+          def target(&block); end
 
           sig { returns(T::Boolean) }
           def target_present?; end
@@ -4806,14 +4806,14 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2::MetricValueStatus) }
-          def current; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::MetricValueStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2::MetricValueStatus) }
+          def current(&block); end
 
           sig { returns(T::Boolean) }
           def current_present?; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2::MetricIdentifier) }
-          def metric; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::MetricIdentifier).void)).returns(KubeDSL::DSL::Autoscaling::V2::MetricIdentifier) }
+          def metric(&block); end
 
           sig { returns(T::Boolean) }
           def metric_present?; end
@@ -4833,8 +4833,8 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def name(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2::MetricTarget) }
-          def target; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::MetricTarget).void)).returns(KubeDSL::DSL::Autoscaling::V2::MetricTarget) }
+          def target(&block); end
 
           sig { returns(T::Boolean) }
           def target_present?; end
@@ -4851,8 +4851,8 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2::MetricValueStatus) }
-          def current; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::MetricValueStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2::MetricValueStatus) }
+          def current(&block); end
 
           sig { returns(T::Boolean) }
           def current_present?; end
@@ -4946,8 +4946,8 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def metric_name(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-          def metric_selector; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+          def metric_selector(&block); end
 
           sig { returns(T::Boolean) }
           def metric_selector_present?; end
@@ -4979,8 +4979,8 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def metric_name(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-          def metric_selector; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+          def metric_selector(&block); end
 
           sig { returns(T::Boolean) }
           def metric_selector_present?; end
@@ -4997,20 +4997,20 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2beta1::HorizontalPodAutoscalerSpec) }
-          def spec; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta1::HorizontalPodAutoscalerSpec).void)).returns(KubeDSL::DSL::Autoscaling::V2beta1::HorizontalPodAutoscalerSpec) }
+          def spec(&block); end
 
           sig { returns(T::Boolean) }
           def spec_present?; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2beta1::HorizontalPodAutoscalerStatus) }
-          def status; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta1::HorizontalPodAutoscalerStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2beta1::HorizontalPodAutoscalerStatus) }
+          def status(&block); end
 
           sig { returns(T::Boolean) }
           def status_present?; end
@@ -5057,8 +5057,8 @@ module KubeDSL
           sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::Autoscaling::V2beta1::HorizontalPodAutoscaler))).returns(T::Array[KubeDSL::DSL::Autoscaling::V2beta1::HorizontalPodAutoscaler]) }
           def items(elem_name = nil, &block); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -5084,8 +5084,8 @@ module KubeDSL
           sig { params(val: T.nilable(Integer)).returns(Integer) }
           def min_replicas(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2beta1::CrossVersionObjectReference) }
-          def scale_target_ref; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta1::CrossVersionObjectReference).void)).returns(KubeDSL::DSL::Autoscaling::V2beta1::CrossVersionObjectReference) }
+          def scale_target_ref(&block); end
 
           sig { returns(T::Boolean) }
           def scale_target_ref_present?; end
@@ -5132,32 +5132,32 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2beta1::ContainerResourceMetricSource) }
-          def container_resource; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta1::ContainerResourceMetricSource).void)).returns(KubeDSL::DSL::Autoscaling::V2beta1::ContainerResourceMetricSource) }
+          def container_resource(&block); end
 
           sig { returns(T::Boolean) }
           def container_resource_present?; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2beta1::ExternalMetricSource) }
-          def external; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta1::ExternalMetricSource).void)).returns(KubeDSL::DSL::Autoscaling::V2beta1::ExternalMetricSource) }
+          def external(&block); end
 
           sig { returns(T::Boolean) }
           def external_present?; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2beta1::ObjectMetricSource) }
-          def object; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta1::ObjectMetricSource).void)).returns(KubeDSL::DSL::Autoscaling::V2beta1::ObjectMetricSource) }
+          def object(&block); end
 
           sig { returns(T::Boolean) }
           def object_present?; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2beta1::PodsMetricSource) }
-          def pods; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta1::PodsMetricSource).void)).returns(KubeDSL::DSL::Autoscaling::V2beta1::PodsMetricSource) }
+          def pods(&block); end
 
           sig { returns(T::Boolean) }
           def pods_present?; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2beta1::ResourceMetricSource) }
-          def resource; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta1::ResourceMetricSource).void)).returns(KubeDSL::DSL::Autoscaling::V2beta1::ResourceMetricSource) }
+          def resource(&block); end
 
           sig { returns(T::Boolean) }
           def resource_present?; end
@@ -5177,32 +5177,32 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2beta1::ContainerResourceMetricStatus) }
-          def container_resource; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta1::ContainerResourceMetricStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2beta1::ContainerResourceMetricStatus) }
+          def container_resource(&block); end
 
           sig { returns(T::Boolean) }
           def container_resource_present?; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2beta1::ExternalMetricStatus) }
-          def external; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta1::ExternalMetricStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2beta1::ExternalMetricStatus) }
+          def external(&block); end
 
           sig { returns(T::Boolean) }
           def external_present?; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2beta1::ObjectMetricStatus) }
-          def object; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta1::ObjectMetricStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2beta1::ObjectMetricStatus) }
+          def object(&block); end
 
           sig { returns(T::Boolean) }
           def object_present?; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2beta1::PodsMetricStatus) }
-          def pods; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta1::PodsMetricStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2beta1::PodsMetricStatus) }
+          def pods(&block); end
 
           sig { returns(T::Boolean) }
           def pods_present?; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2beta1::ResourceMetricStatus) }
-          def resource; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta1::ResourceMetricStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2beta1::ResourceMetricStatus) }
+          def resource(&block); end
 
           sig { returns(T::Boolean) }
           def resource_present?; end
@@ -5228,14 +5228,14 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def metric_name(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-          def selector; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+          def selector(&block); end
 
           sig { returns(T::Boolean) }
           def selector_present?; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2beta1::CrossVersionObjectReference) }
-          def target; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta1::CrossVersionObjectReference).void)).returns(KubeDSL::DSL::Autoscaling::V2beta1::CrossVersionObjectReference) }
+          def target(&block); end
 
           sig { returns(T::Boolean) }
           def target_present?; end
@@ -5264,14 +5264,14 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def metric_name(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-          def selector; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+          def selector(&block); end
 
           sig { returns(T::Boolean) }
           def selector_present?; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2beta1::CrossVersionObjectReference) }
-          def target; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta1::CrossVersionObjectReference).void)).returns(KubeDSL::DSL::Autoscaling::V2beta1::CrossVersionObjectReference) }
+          def target(&block); end
 
           sig { returns(T::Boolean) }
           def target_present?; end
@@ -5291,8 +5291,8 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def metric_name(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-          def selector; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+          def selector(&block); end
 
           sig { returns(T::Boolean) }
           def selector_present?; end
@@ -5318,8 +5318,8 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def metric_name(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-          def selector; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+          def selector(&block); end
 
           sig { returns(T::Boolean) }
           def selector_present?; end
@@ -5386,8 +5386,8 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def name(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricTarget) }
-          def target; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::MetricTarget).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricTarget) }
+          def target(&block); end
 
           sig { returns(T::Boolean) }
           def target_present?; end
@@ -5407,8 +5407,8 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def container(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricValueStatus) }
-          def current; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::MetricValueStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricValueStatus) }
+          def current(&block); end
 
           sig { returns(T::Boolean) }
           def current_present?; end
@@ -5449,14 +5449,14 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricIdentifier) }
-          def metric; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::MetricIdentifier).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricIdentifier) }
+          def metric(&block); end
 
           sig { returns(T::Boolean) }
           def metric_present?; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricTarget) }
-          def target; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::MetricTarget).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricTarget) }
+          def target(&block); end
 
           sig { returns(T::Boolean) }
           def target_present?; end
@@ -5473,14 +5473,14 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricValueStatus) }
-          def current; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::MetricValueStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricValueStatus) }
+          def current(&block); end
 
           sig { returns(T::Boolean) }
           def current_present?; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricIdentifier) }
-          def metric; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::MetricIdentifier).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricIdentifier) }
+          def metric(&block); end
 
           sig { returns(T::Boolean) }
           def metric_present?; end
@@ -5497,20 +5497,20 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::HorizontalPodAutoscalerSpec) }
-          def spec; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::HorizontalPodAutoscalerSpec).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::HorizontalPodAutoscalerSpec) }
+          def spec(&block); end
 
           sig { returns(T::Boolean) }
           def spec_present?; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::HorizontalPodAutoscalerStatus) }
-          def status; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::HorizontalPodAutoscalerStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::HorizontalPodAutoscalerStatus) }
+          def status(&block); end
 
           sig { returns(T::Boolean) }
           def status_present?; end
@@ -5527,14 +5527,14 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::HPAScalingRules) }
-          def scale_down; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::HPAScalingRules).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::HPAScalingRules) }
+          def scale_down(&block); end
 
           sig { returns(T::Boolean) }
           def scale_down_present?; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::HPAScalingRules) }
-          def scale_up; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::HPAScalingRules).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::HPAScalingRules) }
+          def scale_up(&block); end
 
           sig { returns(T::Boolean) }
           def scale_up_present?; end
@@ -5581,8 +5581,8 @@ module KubeDSL
           sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::Autoscaling::V2beta2::HorizontalPodAutoscaler))).returns(T::Array[KubeDSL::DSL::Autoscaling::V2beta2::HorizontalPodAutoscaler]) }
           def items(elem_name = nil, &block); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -5599,8 +5599,8 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::HorizontalPodAutoscalerBehavior) }
-          def behavior; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::HorizontalPodAutoscalerBehavior).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::HorizontalPodAutoscalerBehavior) }
+          def behavior(&block); end
 
           sig { returns(T::Boolean) }
           def behavior_present?; end
@@ -5614,8 +5614,8 @@ module KubeDSL
           sig { params(val: T.nilable(Integer)).returns(Integer) }
           def min_replicas(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::CrossVersionObjectReference) }
-          def scale_target_ref; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::CrossVersionObjectReference).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::CrossVersionObjectReference) }
+          def scale_target_ref(&block); end
 
           sig { returns(T::Boolean) }
           def scale_target_ref_present?; end
@@ -5707,8 +5707,8 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def name(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-          def selector; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+          def selector(&block); end
 
           sig { returns(T::Boolean) }
           def selector_present?; end
@@ -5725,32 +5725,32 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::ContainerResourceMetricSource) }
-          def container_resource; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::ContainerResourceMetricSource).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::ContainerResourceMetricSource) }
+          def container_resource(&block); end
 
           sig { returns(T::Boolean) }
           def container_resource_present?; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::ExternalMetricSource) }
-          def external; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::ExternalMetricSource).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::ExternalMetricSource) }
+          def external(&block); end
 
           sig { returns(T::Boolean) }
           def external_present?; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::ObjectMetricSource) }
-          def object; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::ObjectMetricSource).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::ObjectMetricSource) }
+          def object(&block); end
 
           sig { returns(T::Boolean) }
           def object_present?; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::PodsMetricSource) }
-          def pods; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::PodsMetricSource).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::PodsMetricSource) }
+          def pods(&block); end
 
           sig { returns(T::Boolean) }
           def pods_present?; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::ResourceMetricSource) }
-          def resource; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::ResourceMetricSource).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::ResourceMetricSource) }
+          def resource(&block); end
 
           sig { returns(T::Boolean) }
           def resource_present?; end
@@ -5770,32 +5770,32 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::ContainerResourceMetricStatus) }
-          def container_resource; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::ContainerResourceMetricStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::ContainerResourceMetricStatus) }
+          def container_resource(&block); end
 
           sig { returns(T::Boolean) }
           def container_resource_present?; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::ExternalMetricStatus) }
-          def external; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::ExternalMetricStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::ExternalMetricStatus) }
+          def external(&block); end
 
           sig { returns(T::Boolean) }
           def external_present?; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::ObjectMetricStatus) }
-          def object; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::ObjectMetricStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::ObjectMetricStatus) }
+          def object(&block); end
 
           sig { returns(T::Boolean) }
           def object_present?; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::PodsMetricStatus) }
-          def pods; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::PodsMetricStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::PodsMetricStatus) }
+          def pods(&block); end
 
           sig { returns(T::Boolean) }
           def pods_present?; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::ResourceMetricStatus) }
-          def resource; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::ResourceMetricStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::ResourceMetricStatus) }
+          def resource(&block); end
 
           sig { returns(T::Boolean) }
           def resource_present?; end
@@ -5860,20 +5860,20 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::CrossVersionObjectReference) }
-          def described_object; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::CrossVersionObjectReference).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::CrossVersionObjectReference) }
+          def described_object(&block); end
 
           sig { returns(T::Boolean) }
           def described_object_present?; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricIdentifier) }
-          def metric; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::MetricIdentifier).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricIdentifier) }
+          def metric(&block); end
 
           sig { returns(T::Boolean) }
           def metric_present?; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricTarget) }
-          def target; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::MetricTarget).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricTarget) }
+          def target(&block); end
 
           sig { returns(T::Boolean) }
           def target_present?; end
@@ -5890,20 +5890,20 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricValueStatus) }
-          def current; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::MetricValueStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricValueStatus) }
+          def current(&block); end
 
           sig { returns(T::Boolean) }
           def current_present?; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::CrossVersionObjectReference) }
-          def described_object; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::CrossVersionObjectReference).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::CrossVersionObjectReference) }
+          def described_object(&block); end
 
           sig { returns(T::Boolean) }
           def described_object_present?; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricIdentifier) }
-          def metric; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::MetricIdentifier).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricIdentifier) }
+          def metric(&block); end
 
           sig { returns(T::Boolean) }
           def metric_present?; end
@@ -5920,14 +5920,14 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricIdentifier) }
-          def metric; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::MetricIdentifier).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricIdentifier) }
+          def metric(&block); end
 
           sig { returns(T::Boolean) }
           def metric_present?; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricTarget) }
-          def target; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::MetricTarget).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricTarget) }
+          def target(&block); end
 
           sig { returns(T::Boolean) }
           def target_present?; end
@@ -5944,14 +5944,14 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricValueStatus) }
-          def current; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::MetricValueStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricValueStatus) }
+          def current(&block); end
 
           sig { returns(T::Boolean) }
           def current_present?; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricIdentifier) }
-          def metric; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::MetricIdentifier).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricIdentifier) }
+          def metric(&block); end
 
           sig { returns(T::Boolean) }
           def metric_present?; end
@@ -5971,8 +5971,8 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def name(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricTarget) }
-          def target; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::MetricTarget).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricTarget) }
+          def target(&block); end
 
           sig { returns(T::Boolean) }
           def target_present?; end
@@ -5989,8 +5989,8 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricValueStatus) }
-          def current; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::MetricValueStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricValueStatus) }
+          def current(&block); end
 
           sig { returns(T::Boolean) }
           def current_present?; end
@@ -6014,20 +6014,20 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          sig { returns(KubeDSL::DSL::Batch::V1::CronJobSpec) }
-          def spec; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Batch::V1::CronJobSpec).void)).returns(KubeDSL::DSL::Batch::V1::CronJobSpec) }
+          def spec(&block); end
 
           sig { returns(T::Boolean) }
           def spec_present?; end
 
-          sig { returns(KubeDSL::DSL::Batch::V1::CronJobStatus) }
-          def status; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Batch::V1::CronJobStatus).void)).returns(KubeDSL::DSL::Batch::V1::CronJobStatus) }
+          def status(&block); end
 
           sig { returns(T::Boolean) }
           def status_present?; end
@@ -6047,8 +6047,8 @@ module KubeDSL
           sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::Batch::V1::CronJob))).returns(T::Array[KubeDSL::DSL::Batch::V1::CronJob]) }
           def items(elem_name = nil, &block); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -6071,8 +6071,8 @@ module KubeDSL
           sig { params(val: T.nilable(Integer)).returns(Integer) }
           def failed_jobs_history_limit(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Batch::V1::JobTemplateSpec) }
-          def job_template; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Batch::V1::JobTemplateSpec).void)).returns(KubeDSL::DSL::Batch::V1::JobTemplateSpec) }
+          def job_template(&block); end
 
           sig { returns(T::Boolean) }
           def job_template_present?; end
@@ -6122,20 +6122,20 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          sig { returns(KubeDSL::DSL::Batch::V1::JobSpec) }
-          def spec; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Batch::V1::JobSpec).void)).returns(KubeDSL::DSL::Batch::V1::JobSpec) }
+          def spec(&block); end
 
           sig { returns(T::Boolean) }
           def spec_present?; end
 
-          sig { returns(KubeDSL::DSL::Batch::V1::JobStatus) }
-          def status; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Batch::V1::JobStatus).void)).returns(KubeDSL::DSL::Batch::V1::JobStatus) }
+          def status(&block); end
 
           sig { returns(T::Boolean) }
           def status_present?; end
@@ -6185,8 +6185,8 @@ module KubeDSL
           sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::Batch::V1::Job))).returns(T::Array[KubeDSL::DSL::Batch::V1::Job]) }
           def items(elem_name = nil, &block); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -6221,8 +6221,8 @@ module KubeDSL
           sig { params(val: T.nilable(Integer)).returns(Integer) }
           def parallelism(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-          def selector; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+          def selector(&block); end
 
           sig { returns(T::Boolean) }
           def selector_present?; end
@@ -6230,8 +6230,8 @@ module KubeDSL
           sig { params(val: T.nilable(T::Boolean)).returns(T::Boolean) }
           def suspend(val = nil); end
 
-          sig { returns(KubeDSL::DSL::V1::PodTemplateSpec) }
-          def template; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PodTemplateSpec).void)).returns(KubeDSL::DSL::V1::PodTemplateSpec) }
+          def template(&block); end
 
           sig { returns(T::Boolean) }
           def template_present?; end
@@ -6275,8 +6275,8 @@ module KubeDSL
           sig { params(val: T.nilable(Integer)).returns(Integer) }
           def succeeded(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Batch::V1::UncountedTerminatedPods) }
-          def uncounted_terminated_pods; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Batch::V1::UncountedTerminatedPods).void)).returns(KubeDSL::DSL::Batch::V1::UncountedTerminatedPods) }
+          def uncounted_terminated_pods(&block); end
 
           sig { returns(T::Boolean) }
           def uncounted_terminated_pods_present?; end
@@ -6293,14 +6293,14 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          sig { returns(KubeDSL::DSL::Batch::V1::JobSpec) }
-          def spec; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Batch::V1::JobSpec).void)).returns(KubeDSL::DSL::Batch::V1::JobSpec) }
+          def spec(&block); end
 
           sig { returns(T::Boolean) }
           def spec_present?; end
@@ -6337,20 +6337,20 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          sig { returns(KubeDSL::DSL::Batch::V1beta1::CronJobSpec) }
-          def spec; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Batch::V1beta1::CronJobSpec).void)).returns(KubeDSL::DSL::Batch::V1beta1::CronJobSpec) }
+          def spec(&block); end
 
           sig { returns(T::Boolean) }
           def spec_present?; end
 
-          sig { returns(KubeDSL::DSL::Batch::V1beta1::CronJobStatus) }
-          def status; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Batch::V1beta1::CronJobStatus).void)).returns(KubeDSL::DSL::Batch::V1beta1::CronJobStatus) }
+          def status(&block); end
 
           sig { returns(T::Boolean) }
           def status_present?; end
@@ -6370,8 +6370,8 @@ module KubeDSL
           sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::Batch::V1beta1::CronJob))).returns(T::Array[KubeDSL::DSL::Batch::V1beta1::CronJob]) }
           def items(elem_name = nil, &block); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -6394,8 +6394,8 @@ module KubeDSL
           sig { params(val: T.nilable(Integer)).returns(Integer) }
           def failed_jobs_history_limit(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Batch::V1beta1::JobTemplateSpec) }
-          def job_template; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Batch::V1beta1::JobTemplateSpec).void)).returns(KubeDSL::DSL::Batch::V1beta1::JobTemplateSpec) }
+          def job_template(&block); end
 
           sig { returns(T::Boolean) }
           def job_template_present?; end
@@ -6445,14 +6445,14 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          sig { returns(KubeDSL::DSL::Batch::V1::JobSpec) }
-          def spec; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Batch::V1::JobSpec).void)).returns(KubeDSL::DSL::Batch::V1::JobSpec) }
+          def spec(&block); end
 
           sig { returns(T::Boolean) }
           def spec_present?; end
@@ -6473,20 +6473,20 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          sig { returns(KubeDSL::DSL::Certificates::V1::CertificateSigningRequestSpec) }
-          def spec; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Certificates::V1::CertificateSigningRequestSpec).void)).returns(KubeDSL::DSL::Certificates::V1::CertificateSigningRequestSpec) }
+          def spec(&block); end
 
           sig { returns(T::Boolean) }
           def spec_present?; end
 
-          sig { returns(KubeDSL::DSL::Certificates::V1::CertificateSigningRequestStatus) }
-          def status; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Certificates::V1::CertificateSigningRequestStatus).void)).returns(KubeDSL::DSL::Certificates::V1::CertificateSigningRequestStatus) }
+          def status(&block); end
 
           sig { returns(T::Boolean) }
           def status_present?; end
@@ -6536,8 +6536,8 @@ module KubeDSL
           sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::Certificates::V1::CertificateSigningRequest))).returns(T::Array[KubeDSL::DSL::Certificates::V1::CertificateSigningRequest]) }
           def items(elem_name = nil, &block); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -6557,7 +6557,7 @@ module KubeDSL
           sig { params(val: T.nilable(Integer)).returns(Integer) }
           def expiration_seconds(val = nil); end
 
-          sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+          sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
           def extra(&block); end
 
           sig { params(val: T.nilable(String)).returns(String) }
@@ -6612,14 +6612,14 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          sig { returns(KubeDSL::DSL::Coordination::V1::LeaseSpec) }
-          def spec; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Coordination::V1::LeaseSpec).void)).returns(KubeDSL::DSL::Coordination::V1::LeaseSpec) }
+          def spec(&block); end
 
           sig { returns(T::Boolean) }
           def spec_present?; end
@@ -6639,8 +6639,8 @@ module KubeDSL
           sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::Coordination::V1::Lease))).returns(T::Array[KubeDSL::DSL::Coordination::V1::Lease]) }
           def items(elem_name = nil, &block); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -6691,17 +6691,17 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def addresses(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Discovery::V1::EndpointConditions) }
-          def conditions; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Discovery::V1::EndpointConditions).void)).returns(KubeDSL::DSL::Discovery::V1::EndpointConditions) }
+          def conditions(&block); end
 
           sig { returns(T::Boolean) }
           def conditions_present?; end
 
-          sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+          sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
           def deprecated_topology(&block); end
 
-          sig { returns(KubeDSL::DSL::Discovery::V1::EndpointHints) }
-          def hints; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Discovery::V1::EndpointHints).void)).returns(KubeDSL::DSL::Discovery::V1::EndpointHints) }
+          def hints(&block); end
 
           sig { returns(T::Boolean) }
           def hints_present?; end
@@ -6712,8 +6712,8 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def node_name(val = nil); end
 
-          sig { returns(KubeDSL::DSL::V1::ObjectReference) }
-          def target_ref; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ObjectReference).void)).returns(KubeDSL::DSL::V1::ObjectReference) }
+          def target_ref(&block); end
 
           sig { returns(T::Boolean) }
           def target_ref_present?; end
@@ -6799,8 +6799,8 @@ module KubeDSL
           sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::Discovery::V1::Endpoint))).returns(T::Array[KubeDSL::DSL::Discovery::V1::Endpoint]) }
           def endpoints(elem_name = nil, &block); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -6823,8 +6823,8 @@ module KubeDSL
           sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::Discovery::V1::EndpointSlice))).returns(T::Array[KubeDSL::DSL::Discovery::V1::EndpointSlice]) }
           def items(elem_name = nil, &block); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -6861,14 +6861,14 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def addresses(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Discovery::V1beta1::EndpointConditions) }
-          def conditions; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Discovery::V1beta1::EndpointConditions).void)).returns(KubeDSL::DSL::Discovery::V1beta1::EndpointConditions) }
+          def conditions(&block); end
 
           sig { returns(T::Boolean) }
           def conditions_present?; end
 
-          sig { returns(KubeDSL::DSL::Discovery::V1beta1::EndpointHints) }
-          def hints; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Discovery::V1beta1::EndpointHints).void)).returns(KubeDSL::DSL::Discovery::V1beta1::EndpointHints) }
+          def hints(&block); end
 
           sig { returns(T::Boolean) }
           def hints_present?; end
@@ -6879,13 +6879,13 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def node_name(val = nil); end
 
-          sig { returns(KubeDSL::DSL::V1::ObjectReference) }
-          def target_ref; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ObjectReference).void)).returns(KubeDSL::DSL::V1::ObjectReference) }
+          def target_ref(&block); end
 
           sig { returns(T::Boolean) }
           def target_ref_present?; end
 
-          sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+          sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
           def topology(&block); end
         end
 
@@ -6966,8 +6966,8 @@ module KubeDSL
           sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::Discovery::V1beta1::Endpoint))).returns(T::Array[KubeDSL::DSL::Discovery::V1beta1::Endpoint]) }
           def endpoints(elem_name = nil, &block); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -6990,8 +6990,8 @@ module KubeDSL
           sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::Discovery::V1beta1::EndpointSlice))).returns(T::Array[KubeDSL::DSL::Discovery::V1beta1::EndpointSlice]) }
           def items(elem_name = nil, &block); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -7039,8 +7039,8 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def deprecated_last_timestamp(val = nil); end
 
-          sig { returns(KubeDSL::DSL::V1::EventSource) }
-          def deprecated_source; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::EventSource).void)).returns(KubeDSL::DSL::V1::EventSource) }
+          def deprecated_source(&block); end
 
           sig { returns(T::Boolean) }
           def deprecated_source_present?; end
@@ -7048,8 +7048,8 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def event_time(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -7060,14 +7060,14 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def reason(val = nil); end
 
-          sig { returns(KubeDSL::DSL::V1::ObjectReference) }
-          def regarding; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ObjectReference).void)).returns(KubeDSL::DSL::V1::ObjectReference) }
+          def regarding(&block); end
 
           sig { returns(T::Boolean) }
           def regarding_present?; end
 
-          sig { returns(KubeDSL::DSL::V1::ObjectReference) }
-          def related; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ObjectReference).void)).returns(KubeDSL::DSL::V1::ObjectReference) }
+          def related(&block); end
 
           sig { returns(T::Boolean) }
           def related_present?; end
@@ -7078,8 +7078,8 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def reporting_instance(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Events::V1::EventSeries) }
-          def series; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Events::V1::EventSeries).void)).returns(KubeDSL::DSL::Events::V1::EventSeries) }
+          def series(&block); end
 
           sig { returns(T::Boolean) }
           def series_present?; end
@@ -7102,8 +7102,8 @@ module KubeDSL
           sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::Events::V1::Event))).returns(T::Array[KubeDSL::DSL::Events::V1::Event]) }
           def items(elem_name = nil, &block); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -7152,8 +7152,8 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def deprecated_last_timestamp(val = nil); end
 
-          sig { returns(KubeDSL::DSL::V1::EventSource) }
-          def deprecated_source; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::EventSource).void)).returns(KubeDSL::DSL::V1::EventSource) }
+          def deprecated_source(&block); end
 
           sig { returns(T::Boolean) }
           def deprecated_source_present?; end
@@ -7161,8 +7161,8 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def event_time(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -7173,14 +7173,14 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def reason(val = nil); end
 
-          sig { returns(KubeDSL::DSL::V1::ObjectReference) }
-          def regarding; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ObjectReference).void)).returns(KubeDSL::DSL::V1::ObjectReference) }
+          def regarding(&block); end
 
           sig { returns(T::Boolean) }
           def regarding_present?; end
 
-          sig { returns(KubeDSL::DSL::V1::ObjectReference) }
-          def related; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ObjectReference).void)).returns(KubeDSL::DSL::V1::ObjectReference) }
+          def related(&block); end
 
           sig { returns(T::Boolean) }
           def related_present?; end
@@ -7191,8 +7191,8 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def reporting_instance(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Events::V1beta1::EventSeries) }
-          def series; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Events::V1beta1::EventSeries).void)).returns(KubeDSL::DSL::Events::V1beta1::EventSeries) }
+          def series(&block); end
 
           sig { returns(T::Boolean) }
           def series_present?; end
@@ -7215,8 +7215,8 @@ module KubeDSL
           sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::Events::V1beta1::Event))).returns(T::Array[KubeDSL::DSL::Events::V1beta1::Event]) }
           def items(elem_name = nil, &block); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -7270,20 +7270,20 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          sig { returns(KubeDSL::DSL::Flowcontrol::V1beta1::FlowSchemaSpec) }
-          def spec; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Flowcontrol::V1beta1::FlowSchemaSpec).void)).returns(KubeDSL::DSL::Flowcontrol::V1beta1::FlowSchemaSpec) }
+          def spec(&block); end
 
           sig { returns(T::Boolean) }
           def spec_present?; end
 
-          sig { returns(KubeDSL::DSL::Flowcontrol::V1beta1::FlowSchemaStatus) }
-          def status; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Flowcontrol::V1beta1::FlowSchemaStatus).void)).returns(KubeDSL::DSL::Flowcontrol::V1beta1::FlowSchemaStatus) }
+          def status(&block); end
 
           sig { returns(T::Boolean) }
           def status_present?; end
@@ -7330,8 +7330,8 @@ module KubeDSL
           sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::Flowcontrol::V1beta1::FlowSchema))).returns(T::Array[KubeDSL::DSL::Flowcontrol::V1beta1::FlowSchema]) }
           def items(elem_name = nil, &block); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -7348,8 +7348,8 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Flowcontrol::V1beta1::FlowDistinguisherMethod) }
-          def distinguisher_method; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Flowcontrol::V1beta1::FlowDistinguisherMethod).void)).returns(KubeDSL::DSL::Flowcontrol::V1beta1::FlowDistinguisherMethod) }
+          def distinguisher_method(&block); end
 
           sig { returns(T::Boolean) }
           def distinguisher_method_present?; end
@@ -7357,8 +7357,8 @@ module KubeDSL
           sig { params(val: T.nilable(Integer)).returns(Integer) }
           def matching_precedence(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Flowcontrol::V1beta1::PriorityLevelConfigurationReference) }
-          def priority_level_configuration; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Flowcontrol::V1beta1::PriorityLevelConfigurationReference).void)).returns(KubeDSL::DSL::Flowcontrol::V1beta1::PriorityLevelConfigurationReference) }
+          def priority_level_configuration(&block); end
 
           sig { returns(T::Boolean) }
           def priority_level_configuration_present?; end
@@ -7408,8 +7408,8 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Flowcontrol::V1beta1::QueuingConfiguration) }
-          def queuing; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Flowcontrol::V1beta1::QueuingConfiguration).void)).returns(KubeDSL::DSL::Flowcontrol::V1beta1::QueuingConfiguration) }
+          def queuing(&block); end
 
           sig { returns(T::Boolean) }
           def queuing_present?; end
@@ -7432,8 +7432,8 @@ module KubeDSL
           sig { params(val: T.nilable(Integer)).returns(Integer) }
           def assured_concurrency_shares(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Flowcontrol::V1beta1::LimitResponse) }
-          def limit_response; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Flowcontrol::V1beta1::LimitResponse).void)).returns(KubeDSL::DSL::Flowcontrol::V1beta1::LimitResponse) }
+          def limit_response(&block); end
 
           sig { returns(T::Boolean) }
           def limit_response_present?; end
@@ -7489,20 +7489,20 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          sig { returns(KubeDSL::DSL::Flowcontrol::V1beta1::PriorityLevelConfigurationSpec) }
-          def spec; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Flowcontrol::V1beta1::PriorityLevelConfigurationSpec).void)).returns(KubeDSL::DSL::Flowcontrol::V1beta1::PriorityLevelConfigurationSpec) }
+          def spec(&block); end
 
           sig { returns(T::Boolean) }
           def spec_present?; end
 
-          sig { returns(KubeDSL::DSL::Flowcontrol::V1beta1::PriorityLevelConfigurationStatus) }
-          def status; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Flowcontrol::V1beta1::PriorityLevelConfigurationStatus).void)).returns(KubeDSL::DSL::Flowcontrol::V1beta1::PriorityLevelConfigurationStatus) }
+          def status(&block); end
 
           sig { returns(T::Boolean) }
           def status_present?; end
@@ -7549,8 +7549,8 @@ module KubeDSL
           sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::Flowcontrol::V1beta1::PriorityLevelConfiguration))).returns(T::Array[KubeDSL::DSL::Flowcontrol::V1beta1::PriorityLevelConfiguration]) }
           def items(elem_name = nil, &block); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -7582,8 +7582,8 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Flowcontrol::V1beta1::LimitedPriorityLevelConfiguration) }
-          def limited; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Flowcontrol::V1beta1::LimitedPriorityLevelConfiguration).void)).returns(KubeDSL::DSL::Flowcontrol::V1beta1::LimitedPriorityLevelConfiguration) }
+          def limited(&block); end
 
           sig { returns(T::Boolean) }
           def limited_present?; end
@@ -7684,8 +7684,8 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Flowcontrol::V1beta1::GroupSubject) }
-          def group; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Flowcontrol::V1beta1::GroupSubject).void)).returns(KubeDSL::DSL::Flowcontrol::V1beta1::GroupSubject) }
+          def group(&block); end
 
           sig { returns(T::Boolean) }
           def group_present?; end
@@ -7693,14 +7693,14 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def kind(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Flowcontrol::V1beta1::ServiceAccountSubject) }
-          def service_account; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Flowcontrol::V1beta1::ServiceAccountSubject).void)).returns(KubeDSL::DSL::Flowcontrol::V1beta1::ServiceAccountSubject) }
+          def service_account(&block); end
 
           sig { returns(T::Boolean) }
           def service_account_present?; end
 
-          sig { returns(KubeDSL::DSL::Flowcontrol::V1beta1::UserSubject) }
-          def user; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Flowcontrol::V1beta1::UserSubject).void)).returns(KubeDSL::DSL::Flowcontrol::V1beta1::UserSubject) }
+          def user(&block); end
 
           sig { returns(T::Boolean) }
           def user_present?; end
@@ -7749,20 +7749,20 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          sig { returns(KubeDSL::DSL::Flowcontrol::V1beta2::FlowSchemaSpec) }
-          def spec; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Flowcontrol::V1beta2::FlowSchemaSpec).void)).returns(KubeDSL::DSL::Flowcontrol::V1beta2::FlowSchemaSpec) }
+          def spec(&block); end
 
           sig { returns(T::Boolean) }
           def spec_present?; end
 
-          sig { returns(KubeDSL::DSL::Flowcontrol::V1beta2::FlowSchemaStatus) }
-          def status; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Flowcontrol::V1beta2::FlowSchemaStatus).void)).returns(KubeDSL::DSL::Flowcontrol::V1beta2::FlowSchemaStatus) }
+          def status(&block); end
 
           sig { returns(T::Boolean) }
           def status_present?; end
@@ -7809,8 +7809,8 @@ module KubeDSL
           sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::Flowcontrol::V1beta2::FlowSchema))).returns(T::Array[KubeDSL::DSL::Flowcontrol::V1beta2::FlowSchema]) }
           def items(elem_name = nil, &block); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -7827,8 +7827,8 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Flowcontrol::V1beta2::FlowDistinguisherMethod) }
-          def distinguisher_method; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Flowcontrol::V1beta2::FlowDistinguisherMethod).void)).returns(KubeDSL::DSL::Flowcontrol::V1beta2::FlowDistinguisherMethod) }
+          def distinguisher_method(&block); end
 
           sig { returns(T::Boolean) }
           def distinguisher_method_present?; end
@@ -7836,8 +7836,8 @@ module KubeDSL
           sig { params(val: T.nilable(Integer)).returns(Integer) }
           def matching_precedence(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Flowcontrol::V1beta2::PriorityLevelConfigurationReference) }
-          def priority_level_configuration; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Flowcontrol::V1beta2::PriorityLevelConfigurationReference).void)).returns(KubeDSL::DSL::Flowcontrol::V1beta2::PriorityLevelConfigurationReference) }
+          def priority_level_configuration(&block); end
 
           sig { returns(T::Boolean) }
           def priority_level_configuration_present?; end
@@ -7887,8 +7887,8 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Flowcontrol::V1beta2::QueuingConfiguration) }
-          def queuing; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Flowcontrol::V1beta2::QueuingConfiguration).void)).returns(KubeDSL::DSL::Flowcontrol::V1beta2::QueuingConfiguration) }
+          def queuing(&block); end
 
           sig { returns(T::Boolean) }
           def queuing_present?; end
@@ -7911,8 +7911,8 @@ module KubeDSL
           sig { params(val: T.nilable(Integer)).returns(Integer) }
           def assured_concurrency_shares(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Flowcontrol::V1beta2::LimitResponse) }
-          def limit_response; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Flowcontrol::V1beta2::LimitResponse).void)).returns(KubeDSL::DSL::Flowcontrol::V1beta2::LimitResponse) }
+          def limit_response(&block); end
 
           sig { returns(T::Boolean) }
           def limit_response_present?; end
@@ -7968,20 +7968,20 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          sig { returns(KubeDSL::DSL::Flowcontrol::V1beta2::PriorityLevelConfigurationSpec) }
-          def spec; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Flowcontrol::V1beta2::PriorityLevelConfigurationSpec).void)).returns(KubeDSL::DSL::Flowcontrol::V1beta2::PriorityLevelConfigurationSpec) }
+          def spec(&block); end
 
           sig { returns(T::Boolean) }
           def spec_present?; end
 
-          sig { returns(KubeDSL::DSL::Flowcontrol::V1beta2::PriorityLevelConfigurationStatus) }
-          def status; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Flowcontrol::V1beta2::PriorityLevelConfigurationStatus).void)).returns(KubeDSL::DSL::Flowcontrol::V1beta2::PriorityLevelConfigurationStatus) }
+          def status(&block); end
 
           sig { returns(T::Boolean) }
           def status_present?; end
@@ -8028,8 +8028,8 @@ module KubeDSL
           sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::Flowcontrol::V1beta2::PriorityLevelConfiguration))).returns(T::Array[KubeDSL::DSL::Flowcontrol::V1beta2::PriorityLevelConfiguration]) }
           def items(elem_name = nil, &block); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -8061,8 +8061,8 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Flowcontrol::V1beta2::LimitedPriorityLevelConfiguration) }
-          def limited; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Flowcontrol::V1beta2::LimitedPriorityLevelConfiguration).void)).returns(KubeDSL::DSL::Flowcontrol::V1beta2::LimitedPriorityLevelConfiguration) }
+          def limited(&block); end
 
           sig { returns(T::Boolean) }
           def limited_present?; end
@@ -8163,8 +8163,8 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Flowcontrol::V1beta2::GroupSubject) }
-          def group; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Flowcontrol::V1beta2::GroupSubject).void)).returns(KubeDSL::DSL::Flowcontrol::V1beta2::GroupSubject) }
+          def group(&block); end
 
           sig { returns(T::Boolean) }
           def group_present?; end
@@ -8172,14 +8172,14 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def kind(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Flowcontrol::V1beta2::ServiceAccountSubject) }
-          def service_account; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Flowcontrol::V1beta2::ServiceAccountSubject).void)).returns(KubeDSL::DSL::Flowcontrol::V1beta2::ServiceAccountSubject) }
+          def service_account(&block); end
 
           sig { returns(T::Boolean) }
           def service_account_present?; end
 
-          sig { returns(KubeDSL::DSL::Flowcontrol::V1beta2::UserSubject) }
-          def user; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Flowcontrol::V1beta2::UserSubject).void)).returns(KubeDSL::DSL::Flowcontrol::V1beta2::UserSubject) }
+          def user(&block); end
 
           sig { returns(T::Boolean) }
           def user_present?; end
@@ -8218,8 +8218,8 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def name(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::GroupVersionForDiscovery) }
-          def preferred_version; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::GroupVersionForDiscovery).void)).returns(KubeDSL::DSL::Meta::V1::GroupVersionForDiscovery) }
+          def preferred_version(&block); end
 
           sig { returns(T::Boolean) }
           def preferred_version_present?; end
@@ -8377,8 +8377,8 @@ module KubeDSL
           sig { params(val: T.nilable(T::Boolean)).returns(T::Boolean) }
           def orphan_dependents(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::Preconditions) }
-          def preconditions; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::Preconditions).void)).returns(KubeDSL::DSL::Meta::V1::Preconditions) }
+          def preconditions(&block); end
 
           sig { returns(T::Boolean) }
           def preconditions_present?; end
@@ -8419,7 +8419,7 @@ module KubeDSL
           sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::Meta::V1::LabelSelectorRequirement))).returns(T::Array[KubeDSL::DSL::Meta::V1::LabelSelectorRequirement]) }
           def match_expressions(elem_name = nil, &block); end
 
-          sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+          sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
           def match_labels(&block); end
         end
 
@@ -8512,7 +8512,7 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+          sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
           def annotations(&block); end
 
           sig { params(val: T.nilable(String)).returns(String) }
@@ -8536,7 +8536,7 @@ module KubeDSL
           sig { params(val: T.nilable(Integer)).returns(Integer) }
           def generation(val = nil); end
 
-          sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+          sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
           def labels(&block); end
 
           sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::Meta::V1::ManagedFieldsEntry))).returns(T::Array[KubeDSL::DSL::Meta::V1::ManagedFieldsEntry]) }
@@ -8641,8 +8641,8 @@ module KubeDSL
           sig { params(val: T.nilable(Integer)).returns(Integer) }
           def code(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::StatusDetails) }
-          def details; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::StatusDetails).void)).returns(KubeDSL::DSL::Meta::V1::StatusDetails) }
+          def details(&block); end
 
           sig { returns(T::Boolean) }
           def details_present?; end
@@ -8650,8 +8650,8 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def message(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -8747,8 +8747,8 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Networking::V1::IngressBackend) }
-          def backend; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Networking::V1::IngressBackend).void)).returns(KubeDSL::DSL::Networking::V1::IngressBackend) }
+          def backend(&block); end
 
           sig { returns(T::Boolean) }
           def backend_present?; end
@@ -8786,20 +8786,20 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          sig { returns(KubeDSL::DSL::Networking::V1::IngressSpec) }
-          def spec; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Networking::V1::IngressSpec).void)).returns(KubeDSL::DSL::Networking::V1::IngressSpec) }
+          def spec(&block); end
 
           sig { returns(T::Boolean) }
           def spec_present?; end
 
-          sig { returns(KubeDSL::DSL::Networking::V1::IngressStatus) }
-          def status; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Networking::V1::IngressStatus).void)).returns(KubeDSL::DSL::Networking::V1::IngressStatus) }
+          def status(&block); end
 
           sig { returns(T::Boolean) }
           def status_present?; end
@@ -8816,14 +8816,14 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::V1::TypedLocalObjectReference) }
-          def resource; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::TypedLocalObjectReference).void)).returns(KubeDSL::DSL::V1::TypedLocalObjectReference) }
+          def resource(&block); end
 
           sig { returns(T::Boolean) }
           def resource_present?; end
 
-          sig { returns(KubeDSL::DSL::Networking::V1::IngressServiceBackend) }
-          def service; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Networking::V1::IngressServiceBackend).void)).returns(KubeDSL::DSL::Networking::V1::IngressServiceBackend) }
+          def service(&block); end
 
           sig { returns(T::Boolean) }
           def service_present?; end
@@ -8840,14 +8840,14 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          sig { returns(KubeDSL::DSL::Networking::V1::IngressClassSpec) }
-          def spec; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Networking::V1::IngressClassSpec).void)).returns(KubeDSL::DSL::Networking::V1::IngressClassSpec) }
+          def spec(&block); end
 
           sig { returns(T::Boolean) }
           def spec_present?; end
@@ -8867,8 +8867,8 @@ module KubeDSL
           sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::Networking::V1::IngressClass))).returns(T::Array[KubeDSL::DSL::Networking::V1::IngressClass]) }
           def items(elem_name = nil, &block); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -8915,8 +8915,8 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def controller(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Networking::V1::IngressClassParametersReference) }
-          def parameters; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Networking::V1::IngressClassParametersReference).void)).returns(KubeDSL::DSL::Networking::V1::IngressClassParametersReference) }
+          def parameters(&block); end
 
           sig { returns(T::Boolean) }
           def parameters_present?; end
@@ -8936,8 +8936,8 @@ module KubeDSL
           sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::Networking::V1::Ingress))).returns(T::Array[KubeDSL::DSL::Networking::V1::Ingress]) }
           def items(elem_name = nil, &block); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -8957,8 +8957,8 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def host(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Networking::V1::HTTPIngressRuleValue) }
-          def http; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Networking::V1::HTTPIngressRuleValue).void)).returns(KubeDSL::DSL::Networking::V1::HTTPIngressRuleValue) }
+          def http(&block); end
 
           sig { returns(T::Boolean) }
           def http_present?; end
@@ -8978,8 +8978,8 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def name(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Networking::V1::ServiceBackendPort) }
-          def port; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Networking::V1::ServiceBackendPort).void)).returns(KubeDSL::DSL::Networking::V1::ServiceBackendPort) }
+          def port(&block); end
 
           sig { returns(T::Boolean) }
           def port_present?; end
@@ -8996,8 +8996,8 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Networking::V1::IngressBackend) }
-          def default_backend; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Networking::V1::IngressBackend).void)).returns(KubeDSL::DSL::Networking::V1::IngressBackend) }
+          def default_backend(&block); end
 
           sig { returns(T::Boolean) }
           def default_backend_present?; end
@@ -9023,8 +9023,8 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::V1::LoadBalancerStatus) }
-          def load_balancer; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::LoadBalancerStatus).void)).returns(KubeDSL::DSL::V1::LoadBalancerStatus) }
+          def load_balancer(&block); end
 
           sig { returns(T::Boolean) }
           def load_balancer_present?; end
@@ -9077,14 +9077,14 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          sig { returns(KubeDSL::DSL::Networking::V1::NetworkPolicySpec) }
-          def spec; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Networking::V1::NetworkPolicySpec).void)).returns(KubeDSL::DSL::Networking::V1::NetworkPolicySpec) }
+          def spec(&block); end
 
           sig { returns(T::Boolean) }
           def spec_present?; end
@@ -9140,8 +9140,8 @@ module KubeDSL
           sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::Networking::V1::NetworkPolicy))).returns(T::Array[KubeDSL::DSL::Networking::V1::NetworkPolicy]) }
           def items(elem_name = nil, &block); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -9158,20 +9158,20 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Networking::V1::IPBlock) }
-          def ip_block; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Networking::V1::IPBlock).void)).returns(KubeDSL::DSL::Networking::V1::IPBlock) }
+          def ip_block(&block); end
 
           sig { returns(T::Boolean) }
           def ip_block_present?; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-          def namespace_selector; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+          def namespace_selector(&block); end
 
           sig { returns(T::Boolean) }
           def namespace_selector_present?; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-          def pod_selector; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+          def pod_selector(&block); end
 
           sig { returns(T::Boolean) }
           def pod_selector_present?; end
@@ -9215,8 +9215,8 @@ module KubeDSL
           sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::Networking::V1::NetworkPolicyIngressRule))).returns(T::Array[KubeDSL::DSL::Networking::V1::NetworkPolicyIngressRule]) }
           def ingresses(elem_name = nil, &block); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-          def pod_selector; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+          def pod_selector(&block); end
 
           sig { returns(T::Boolean) }
           def pod_selector_present?; end
@@ -9258,20 +9258,20 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          sig { returns(KubeDSL::DSL::V1::NodeSpec) }
-          def spec; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::NodeSpec).void)).returns(KubeDSL::DSL::V1::NodeSpec) }
+          def spec(&block); end
 
           sig { returns(T::Boolean) }
           def spec_present?; end
 
-          sig { returns(KubeDSL::DSL::V1::NodeStatus) }
-          def status; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::NodeStatus).void)).returns(KubeDSL::DSL::V1::NodeStatus) }
+          def status(&block); end
 
           sig { returns(T::Boolean) }
           def status_present?; end
@@ -9288,20 +9288,20 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          sig { returns(KubeDSL::DSL::V1::NodeSpec) }
-          def spec; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::NodeSpec).void)).returns(KubeDSL::DSL::V1::NodeSpec) }
+          def spec(&block); end
 
           sig { returns(T::Boolean) }
           def spec_present?; end
 
-          sig { returns(KubeDSL::DSL::V1::NodeStatus) }
-          def status; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::NodeStatus).void)).returns(KubeDSL::DSL::V1::NodeStatus) }
+          def status(&block); end
 
           sig { returns(T::Boolean) }
           def status_present?; end
@@ -9318,20 +9318,20 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          sig { returns(KubeDSL::DSL::V1::NodeSpec) }
-          def spec; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::NodeSpec).void)).returns(KubeDSL::DSL::V1::NodeSpec) }
+          def spec(&block); end
 
           sig { returns(T::Boolean) }
           def spec_present?; end
 
-          sig { returns(KubeDSL::DSL::V1::NodeStatus) }
-          def status; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::NodeStatus).void)).returns(KubeDSL::DSL::V1::NodeStatus) }
+          def status(&block); end
 
           sig { returns(T::Boolean) }
           def status_present?; end
@@ -9348,20 +9348,20 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          sig { returns(KubeDSL::DSL::V1::NodeSpec) }
-          def spec; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::NodeSpec).void)).returns(KubeDSL::DSL::V1::NodeSpec) }
+          def spec(&block); end
 
           sig { returns(T::Boolean) }
           def spec_present?; end
 
-          sig { returns(KubeDSL::DSL::V1::NodeStatus) }
-          def status; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::NodeStatus).void)).returns(KubeDSL::DSL::V1::NodeStatus) }
+          def status(&block); end
 
           sig { returns(T::Boolean) }
           def status_present?; end
@@ -9380,7 +9380,7 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+          sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
           def pod_fixed(&block); end
         end
 
@@ -9395,14 +9395,14 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          sig { returns(KubeDSL::DSL::Node::V1alpha1::RuntimeClassSpec) }
-          def spec; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Node::V1alpha1::RuntimeClassSpec).void)).returns(KubeDSL::DSL::Node::V1alpha1::RuntimeClassSpec) }
+          def spec(&block); end
 
           sig { returns(T::Boolean) }
           def spec_present?; end
@@ -9422,8 +9422,8 @@ module KubeDSL
           sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::Node::V1alpha1::RuntimeClass))).returns(T::Array[KubeDSL::DSL::Node::V1alpha1::RuntimeClass]) }
           def items(elem_name = nil, &block); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -9440,8 +9440,8 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Node::V1alpha1::Overhead) }
-          def overhead; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Node::V1alpha1::Overhead).void)).returns(KubeDSL::DSL::Node::V1alpha1::Overhead) }
+          def overhead(&block); end
 
           sig { returns(T::Boolean) }
           def overhead_present?; end
@@ -9449,8 +9449,8 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def runtime_handler(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Node::V1alpha1::Scheduling) }
-          def scheduling; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Node::V1alpha1::Scheduling).void)).returns(KubeDSL::DSL::Node::V1alpha1::Scheduling) }
+          def scheduling(&block); end
 
           sig { returns(T::Boolean) }
           def scheduling_present?; end
@@ -9467,7 +9467,7 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+          sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
           def node_selector(&block); end
 
           sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::V1::Toleration))).returns(T::Array[KubeDSL::DSL::V1::Toleration]) }
@@ -9487,7 +9487,7 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+          sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
           def pod_fixed(&block); end
         end
 
@@ -9505,20 +9505,20 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def handler(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          sig { returns(KubeDSL::DSL::Node::V1beta1::Overhead) }
-          def overhead; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Node::V1beta1::Overhead).void)).returns(KubeDSL::DSL::Node::V1beta1::Overhead) }
+          def overhead(&block); end
 
           sig { returns(T::Boolean) }
           def overhead_present?; end
 
-          sig { returns(KubeDSL::DSL::Node::V1beta1::Scheduling) }
-          def scheduling; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Node::V1beta1::Scheduling).void)).returns(KubeDSL::DSL::Node::V1beta1::Scheduling) }
+          def scheduling(&block); end
 
           sig { returns(T::Boolean) }
           def scheduling_present?; end
@@ -9538,8 +9538,8 @@ module KubeDSL
           sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::Node::V1beta1::RuntimeClass))).returns(T::Array[KubeDSL::DSL::Node::V1beta1::RuntimeClass]) }
           def items(elem_name = nil, &block); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -9556,7 +9556,7 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+          sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
           def node_selector(&block); end
 
           sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::V1::Toleration))).returns(T::Array[KubeDSL::DSL::V1::Toleration]) }
@@ -9578,14 +9578,14 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::DeleteOptions) }
-          def delete_options; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::DeleteOptions).void)).returns(KubeDSL::DSL::Meta::V1::DeleteOptions) }
+          def delete_options(&block); end
 
           sig { returns(T::Boolean) }
           def delete_options_present?; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -9602,20 +9602,20 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          sig { returns(KubeDSL::DSL::Policy::V1::PodDisruptionBudgetSpec) }
-          def spec; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Policy::V1::PodDisruptionBudgetSpec).void)).returns(KubeDSL::DSL::Policy::V1::PodDisruptionBudgetSpec) }
+          def spec(&block); end
 
           sig { returns(T::Boolean) }
           def spec_present?; end
 
-          sig { returns(KubeDSL::DSL::Policy::V1::PodDisruptionBudgetStatus) }
-          def status; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Policy::V1::PodDisruptionBudgetStatus).void)).returns(KubeDSL::DSL::Policy::V1::PodDisruptionBudgetStatus) }
+          def status(&block); end
 
           sig { returns(T::Boolean) }
           def status_present?; end
@@ -9635,8 +9635,8 @@ module KubeDSL
           sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::Policy::V1::PodDisruptionBudget))).returns(T::Array[KubeDSL::DSL::Policy::V1::PodDisruptionBudget]) }
           def items(elem_name = nil, &block); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -9659,8 +9659,8 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def min_available(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-          def selector; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+          def selector(&block); end
 
           sig { returns(T::Boolean) }
           def selector_present?; end
@@ -9686,7 +9686,7 @@ module KubeDSL
           sig { params(val: T.nilable(Integer)).returns(Integer) }
           def desired_healthy(val = nil); end
 
-          sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+          sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
           def disrupted_pods(&block); end
 
           sig { params(val: T.nilable(Integer)).returns(Integer) }
@@ -9814,20 +9814,20 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          sig { returns(KubeDSL::DSL::Policy::V1beta1::PodDisruptionBudgetSpec) }
-          def spec; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Policy::V1beta1::PodDisruptionBudgetSpec).void)).returns(KubeDSL::DSL::Policy::V1beta1::PodDisruptionBudgetSpec) }
+          def spec(&block); end
 
           sig { returns(T::Boolean) }
           def spec_present?; end
 
-          sig { returns(KubeDSL::DSL::Policy::V1beta1::PodDisruptionBudgetStatus) }
-          def status; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Policy::V1beta1::PodDisruptionBudgetStatus).void)).returns(KubeDSL::DSL::Policy::V1beta1::PodDisruptionBudgetStatus) }
+          def status(&block); end
 
           sig { returns(T::Boolean) }
           def status_present?; end
@@ -9847,8 +9847,8 @@ module KubeDSL
           sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::Policy::V1beta1::PodDisruptionBudget))).returns(T::Array[KubeDSL::DSL::Policy::V1beta1::PodDisruptionBudget]) }
           def items(elem_name = nil, &block); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -9871,8 +9871,8 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def min_available(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-          def selector; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+          def selector(&block); end
 
           sig { returns(T::Boolean) }
           def selector_present?; end
@@ -9898,7 +9898,7 @@ module KubeDSL
           sig { params(val: T.nilable(Integer)).returns(Integer) }
           def desired_healthy(val = nil); end
 
-          sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+          sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
           def disrupted_pods(&block); end
 
           sig { params(val: T.nilable(Integer)).returns(Integer) }
@@ -9922,14 +9922,14 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          sig { returns(KubeDSL::DSL::Policy::V1beta1::PodSecurityPolicySpec) }
-          def spec; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Policy::V1beta1::PodSecurityPolicySpec).void)).returns(KubeDSL::DSL::Policy::V1beta1::PodSecurityPolicySpec) }
+          def spec(&block); end
 
           sig { returns(T::Boolean) }
           def spec_present?; end
@@ -9949,8 +9949,8 @@ module KubeDSL
           sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::Policy::V1beta1::PodSecurityPolicy))).returns(T::Array[KubeDSL::DSL::Policy::V1beta1::PodSecurityPolicy]) }
           def items(elem_name = nil, &block); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -9997,8 +9997,8 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def forbidden_sysctls(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Policy::V1beta1::FSGroupStrategyOptions) }
-          def fs_group; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Policy::V1beta1::FSGroupStrategyOptions).void)).returns(KubeDSL::DSL::Policy::V1beta1::FSGroupStrategyOptions) }
+          def fs_group(&block); end
 
           sig { returns(T::Boolean) }
           def fs_group_present?; end
@@ -10024,32 +10024,32 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def required_drop_capabilities(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Policy::V1beta1::RunAsGroupStrategyOptions) }
-          def run_as_group; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Policy::V1beta1::RunAsGroupStrategyOptions).void)).returns(KubeDSL::DSL::Policy::V1beta1::RunAsGroupStrategyOptions) }
+          def run_as_group(&block); end
 
           sig { returns(T::Boolean) }
           def run_as_group_present?; end
 
-          sig { returns(KubeDSL::DSL::Policy::V1beta1::RunAsUserStrategyOptions) }
-          def run_as_user; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Policy::V1beta1::RunAsUserStrategyOptions).void)).returns(KubeDSL::DSL::Policy::V1beta1::RunAsUserStrategyOptions) }
+          def run_as_user(&block); end
 
           sig { returns(T::Boolean) }
           def run_as_user_present?; end
 
-          sig { returns(KubeDSL::DSL::Policy::V1beta1::RuntimeClassStrategyOptions) }
-          def runtime_class; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Policy::V1beta1::RuntimeClassStrategyOptions).void)).returns(KubeDSL::DSL::Policy::V1beta1::RuntimeClassStrategyOptions) }
+          def runtime_class(&block); end
 
           sig { returns(T::Boolean) }
           def runtime_class_present?; end
 
-          sig { returns(KubeDSL::DSL::Policy::V1beta1::SELinuxStrategyOptions) }
-          def se_linux; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Policy::V1beta1::SELinuxStrategyOptions).void)).returns(KubeDSL::DSL::Policy::V1beta1::SELinuxStrategyOptions) }
+          def se_linux(&block); end
 
           sig { returns(T::Boolean) }
           def se_linux_present?; end
 
-          sig { returns(KubeDSL::DSL::Policy::V1beta1::SupplementalGroupsStrategyOptions) }
-          def supplemental_groups; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Policy::V1beta1::SupplementalGroupsStrategyOptions).void)).returns(KubeDSL::DSL::Policy::V1beta1::SupplementalGroupsStrategyOptions) }
+          def supplemental_groups(&block); end
 
           sig { returns(T::Boolean) }
           def supplemental_groups_present?; end
@@ -10126,8 +10126,8 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def rule(val = nil); end
 
-          sig { returns(KubeDSL::DSL::V1::SELinuxOptions) }
-          def se_linux_options; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::SELinuxOptions).void)).returns(KubeDSL::DSL::V1::SELinuxOptions) }
+          def se_linux_options(&block); end
 
           sig { returns(T::Boolean) }
           def se_linux_options_present?; end
@@ -10181,14 +10181,14 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Rbac::V1::AggregationRule) }
-          def aggregation_rule; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Rbac::V1::AggregationRule).void)).returns(KubeDSL::DSL::Rbac::V1::AggregationRule) }
+          def aggregation_rule(&block); end
 
           sig { returns(T::Boolean) }
           def aggregation_rule_present?; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -10208,14 +10208,14 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          sig { returns(KubeDSL::DSL::Rbac::V1::RoleRef) }
-          def role_ref; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Rbac::V1::RoleRef).void)).returns(KubeDSL::DSL::Rbac::V1::RoleRef) }
+          def role_ref(&block); end
 
           sig { returns(T::Boolean) }
           def role_ref_present?; end
@@ -10238,8 +10238,8 @@ module KubeDSL
           sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::Rbac::V1::ClusterRoleBinding))).returns(T::Array[KubeDSL::DSL::Rbac::V1::ClusterRoleBinding]) }
           def items(elem_name = nil, &block); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -10259,8 +10259,8 @@ module KubeDSL
           sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::Rbac::V1::ClusterRole))).returns(T::Array[KubeDSL::DSL::Rbac::V1::ClusterRole]) }
           def items(elem_name = nil, &block); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -10304,8 +10304,8 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -10325,14 +10325,14 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          sig { returns(KubeDSL::DSL::Rbac::V1::RoleRef) }
-          def role_ref; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Rbac::V1::RoleRef).void)).returns(KubeDSL::DSL::Rbac::V1::RoleRef) }
+          def role_ref(&block); end
 
           sig { returns(T::Boolean) }
           def role_ref_present?; end
@@ -10355,8 +10355,8 @@ module KubeDSL
           sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::Rbac::V1::RoleBinding))).returns(T::Array[KubeDSL::DSL::Rbac::V1::RoleBinding]) }
           def items(elem_name = nil, &block); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -10376,8 +10376,8 @@ module KubeDSL
           sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::Rbac::V1::Role))).returns(T::Array[KubeDSL::DSL::Rbac::V1::Role]) }
           def items(elem_name = nil, &block); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -10449,8 +10449,8 @@ module KubeDSL
           sig { params(val: T.nilable(T::Boolean)).returns(T::Boolean) }
           def global_default(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -10476,8 +10476,8 @@ module KubeDSL
           sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::Scheduling::V1::PriorityClass))).returns(T::Array[KubeDSL::DSL::Scheduling::V1::PriorityClass]) }
           def items(elem_name = nil, &block); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -10498,14 +10498,14 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          sig { returns(KubeDSL::DSL::Storage::V1::CSIDriverSpec) }
-          def spec; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Storage::V1::CSIDriverSpec).void)).returns(KubeDSL::DSL::Storage::V1::CSIDriverSpec) }
+          def spec(&block); end
 
           sig { returns(T::Boolean) }
           def spec_present?; end
@@ -10525,8 +10525,8 @@ module KubeDSL
           sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::Storage::V1::CSIDriver))).returns(T::Array[KubeDSL::DSL::Storage::V1::CSIDriver]) }
           def items(elem_name = nil, &block); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -10576,14 +10576,14 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          sig { returns(KubeDSL::DSL::Storage::V1::CSINodeSpec) }
-          def spec; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Storage::V1::CSINodeSpec).void)).returns(KubeDSL::DSL::Storage::V1::CSINodeSpec) }
+          def spec(&block); end
 
           sig { returns(T::Boolean) }
           def spec_present?; end
@@ -10600,8 +10600,8 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Storage::V1::VolumeNodeResources) }
-          def allocatable; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Storage::V1::VolumeNodeResources).void)).returns(KubeDSL::DSL::Storage::V1::VolumeNodeResources) }
+          def allocatable(&block); end
 
           sig { returns(T::Boolean) }
           def allocatable_present?; end
@@ -10630,8 +10630,8 @@ module KubeDSL
           sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::Storage::V1::CSINode))).returns(T::Array[KubeDSL::DSL::Storage::V1::CSINode]) }
           def items(elem_name = nil, &block); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -10669,8 +10669,8 @@ module KubeDSL
           sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::V1::TopologySelectorTerm))).returns(T::Array[KubeDSL::DSL::V1::TopologySelectorTerm]) }
           def allowed_topologies(elem_name = nil, &block); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -10678,7 +10678,7 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def mount_options(val = nil); end
 
-          sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+          sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
           def parameters(&block); end
 
           sig { params(val: T.nilable(String)).returns(String) }
@@ -10705,8 +10705,8 @@ module KubeDSL
           sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::Storage::V1::StorageClass))).returns(T::Array[KubeDSL::DSL::Storage::V1::StorageClass]) }
           def items(elem_name = nil, &block); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -10741,20 +10741,20 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          sig { returns(KubeDSL::DSL::Storage::V1::VolumeAttachmentSpec) }
-          def spec; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Storage::V1::VolumeAttachmentSpec).void)).returns(KubeDSL::DSL::Storage::V1::VolumeAttachmentSpec) }
+          def spec(&block); end
 
           sig { returns(T::Boolean) }
           def spec_present?; end
 
-          sig { returns(KubeDSL::DSL::Storage::V1::VolumeAttachmentStatus) }
-          def status; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Storage::V1::VolumeAttachmentStatus).void)).returns(KubeDSL::DSL::Storage::V1::VolumeAttachmentStatus) }
+          def status(&block); end
 
           sig { returns(T::Boolean) }
           def status_present?; end
@@ -10774,8 +10774,8 @@ module KubeDSL
           sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::Storage::V1::VolumeAttachment))).returns(T::Array[KubeDSL::DSL::Storage::V1::VolumeAttachment]) }
           def items(elem_name = nil, &block); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -10792,8 +10792,8 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::V1::PersistentVolumeSpec) }
-          def inline_volume_spec; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PersistentVolumeSpec).void)).returns(KubeDSL::DSL::V1::PersistentVolumeSpec) }
+          def inline_volume_spec(&block); end
 
           sig { returns(T::Boolean) }
           def inline_volume_spec_present?; end
@@ -10819,8 +10819,8 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def node_name(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Storage::V1::VolumeAttachmentSource) }
-          def source; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Storage::V1::VolumeAttachmentSource).void)).returns(KubeDSL::DSL::Storage::V1::VolumeAttachmentSource) }
+          def source(&block); end
 
           sig { returns(T::Boolean) }
           def source_present?; end
@@ -10837,8 +10837,8 @@ module KubeDSL
           sig { returns(Symbol) }
           def kind_sym; end
 
-          sig { returns(KubeDSL::DSL::Storage::V1::VolumeError) }
-          def attach_error; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Storage::V1::VolumeError).void)).returns(KubeDSL::DSL::Storage::V1::VolumeError) }
+          def attach_error(&block); end
 
           sig { returns(T::Boolean) }
           def attach_error_present?; end
@@ -10846,11 +10846,11 @@ module KubeDSL
           sig { params(val: T.nilable(T::Boolean)).returns(T::Boolean) }
           def attached(val = nil); end
 
-          sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+          sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
           def attachment_metadata(&block); end
 
-          sig { returns(KubeDSL::DSL::Storage::V1::VolumeError) }
-          def detach_error; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Storage::V1::VolumeError).void)).returns(KubeDSL::DSL::Storage::V1::VolumeError) }
+          def detach_error(&block); end
 
           sig { returns(T::Boolean) }
           def detach_error_present?; end
@@ -10908,14 +10908,14 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def maximum_volume_size(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-          def node_topology; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+          def node_topology(&block); end
 
           sig { returns(T::Boolean) }
           def node_topology_present?; end
@@ -10938,8 +10938,8 @@ module KubeDSL
           sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::Storage::V1alpha1::CSIStorageCapacity))).returns(T::Array[KubeDSL::DSL::Storage::V1alpha1::CSIStorageCapacity]) }
           def items(elem_name = nil, &block); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -10964,14 +10964,14 @@ module KubeDSL
           sig { params(val: T.nilable(String)).returns(String) }
           def maximum_volume_size(val = nil); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-          def node_topology; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+          def node_topology(&block); end
 
           sig { returns(T::Boolean) }
           def node_topology_present?; end
@@ -10994,8 +10994,8 @@ module KubeDSL
           sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::Storage::V1beta1::CSIStorageCapacity))).returns(T::Array[KubeDSL::DSL::Storage::V1beta1::CSIStorageCapacity]) }
           def items(elem_name = nil, &block); end
 
-          sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
 
           sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -11015,20 +11015,20 @@ module KubeDSL
         sig { returns(Symbol) }
         def kind_sym; end
 
-        sig { returns(KubeDSL::DSL::V1::NodeAffinity) }
-        def node_affinity; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::NodeAffinity).void)).returns(KubeDSL::DSL::V1::NodeAffinity) }
+        def node_affinity(&block); end
 
         sig { returns(T::Boolean) }
         def node_affinity_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::PodAffinity) }
-        def pod_affinity; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PodAffinity).void)).returns(KubeDSL::DSL::V1::PodAffinity) }
+        def pod_affinity(&block); end
 
         sig { returns(T::Boolean) }
         def pod_affinity_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::PodAntiAffinity) }
-        def pod_anti_affinity; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PodAntiAffinity).void)).returns(KubeDSL::DSL::V1::PodAntiAffinity) }
+        def pod_anti_affinity(&block); end
 
         sig { returns(T::Boolean) }
         def pod_anti_affinity_present?; end
@@ -11162,14 +11162,14 @@ module KubeDSL
         sig { returns(Symbol) }
         def kind_sym; end
 
-        sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-        def metadata; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+        def metadata(&block); end
 
         sig { returns(T::Boolean) }
         def metadata_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::ObjectReference) }
-        def target; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ObjectReference).void)).returns(KubeDSL::DSL::V1::ObjectReference) }
+        def target(&block); end
 
         sig { returns(T::Boolean) }
         def target_present?; end
@@ -11216,8 +11216,8 @@ module KubeDSL
         sig { params(val: T.nilable(String)).returns(String) }
         def secret_file(val = nil); end
 
-        sig { returns(KubeDSL::DSL::V1::SecretReference) }
-        def secret_ref; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::SecretReference).void)).returns(KubeDSL::DSL::V1::SecretReference) }
+        def secret_ref(&block); end
 
         sig { returns(T::Boolean) }
         def secret_ref_present?; end
@@ -11249,8 +11249,8 @@ module KubeDSL
         sig { params(val: T.nilable(String)).returns(String) }
         def secret_file(val = nil); end
 
-        sig { returns(KubeDSL::DSL::V1::LocalObjectReference) }
-        def secret_ref; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::LocalObjectReference).void)).returns(KubeDSL::DSL::V1::LocalObjectReference) }
+        def secret_ref(&block); end
 
         sig { returns(T::Boolean) }
         def secret_ref_present?; end
@@ -11276,8 +11276,8 @@ module KubeDSL
         sig { params(val: T.nilable(T::Boolean)).returns(T::Boolean) }
         def read_only(val = nil); end
 
-        sig { returns(KubeDSL::DSL::V1::SecretReference) }
-        def secret_ref; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::SecretReference).void)).returns(KubeDSL::DSL::V1::SecretReference) }
+        def secret_ref(&block); end
 
         sig { returns(T::Boolean) }
         def secret_ref_present?; end
@@ -11303,8 +11303,8 @@ module KubeDSL
         sig { params(val: T.nilable(T::Boolean)).returns(T::Boolean) }
         def read_only(val = nil); end
 
-        sig { returns(KubeDSL::DSL::V1::LocalObjectReference) }
-        def secret_ref; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::LocalObjectReference).void)).returns(KubeDSL::DSL::V1::LocalObjectReference) }
+        def secret_ref(&block); end
 
         sig { returns(T::Boolean) }
         def secret_ref_present?; end
@@ -11366,8 +11366,8 @@ module KubeDSL
         sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::V1::ComponentCondition))).returns(T::Array[KubeDSL::DSL::V1::ComponentCondition]) }
         def conditions(elem_name = nil, &block); end
 
-        sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-        def metadata; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+        def metadata(&block); end
 
         sig { returns(T::Boolean) }
         def metadata_present?; end
@@ -11387,8 +11387,8 @@ module KubeDSL
         sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::V1::ComponentStatus))).returns(T::Array[KubeDSL::DSL::V1::ComponentStatus]) }
         def items(elem_name = nil, &block); end
 
-        sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-        def metadata; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+        def metadata(&block); end
 
         sig { returns(T::Boolean) }
         def metadata_present?; end
@@ -11405,17 +11405,17 @@ module KubeDSL
         sig { returns(Symbol) }
         def kind_sym; end
 
-        sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+        sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
         def binary_data(&block); end
 
-        sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+        sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
         def data(&block); end
 
         sig { params(val: T.nilable(T::Boolean)).returns(T::Boolean) }
         def immutable(val = nil); end
 
-        sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-        def metadata; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+        def metadata(&block); end
 
         sig { returns(T::Boolean) }
         def metadata_present?; end
@@ -11474,8 +11474,8 @@ module KubeDSL
         sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::V1::ConfigMap))).returns(T::Array[KubeDSL::DSL::V1::ConfigMap]) }
         def items(elem_name = nil, &block); end
 
-        sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-        def metadata; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+        def metadata(&block); end
 
         sig { returns(T::Boolean) }
         def metadata_present?; end
@@ -11582,14 +11582,14 @@ module KubeDSL
         sig { params(val: T.nilable(String)).returns(String) }
         def image_pull_policy(val = nil); end
 
-        sig { returns(KubeDSL::DSL::V1::Lifecycle) }
-        def lifecycle; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::Lifecycle).void)).returns(KubeDSL::DSL::V1::Lifecycle) }
+        def lifecycle(&block); end
 
         sig { returns(T::Boolean) }
         def lifecycle_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::Probe) }
-        def liveness_probe; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::Probe).void)).returns(KubeDSL::DSL::V1::Probe) }
+        def liveness_probe(&block); end
 
         sig { returns(T::Boolean) }
         def liveness_probe_present?; end
@@ -11600,26 +11600,26 @@ module KubeDSL
         sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::V1::ContainerPort))).returns(T::Array[KubeDSL::DSL::V1::ContainerPort]) }
         def ports(elem_name = nil, &block); end
 
-        sig { returns(KubeDSL::DSL::V1::Probe) }
-        def readiness_probe; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::Probe).void)).returns(KubeDSL::DSL::V1::Probe) }
+        def readiness_probe(&block); end
 
         sig { returns(T::Boolean) }
         def readiness_probe_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::ResourceRequirements) }
-        def resources; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ResourceRequirements).void)).returns(KubeDSL::DSL::V1::ResourceRequirements) }
+        def resources(&block); end
 
         sig { returns(T::Boolean) }
         def resources_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::SecurityContext) }
-        def security_context; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::SecurityContext).void)).returns(KubeDSL::DSL::V1::SecurityContext) }
+        def security_context(&block); end
 
         sig { returns(T::Boolean) }
         def security_context_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::Probe) }
-        def startup_probe; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::Probe).void)).returns(KubeDSL::DSL::V1::Probe) }
+        def startup_probe(&block); end
 
         sig { returns(T::Boolean) }
         def startup_probe_present?; end
@@ -11705,20 +11705,20 @@ module KubeDSL
         sig { returns(Symbol) }
         def kind_sym; end
 
-        sig { returns(KubeDSL::DSL::V1::ContainerStateRunning) }
-        def running; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ContainerStateRunning).void)).returns(KubeDSL::DSL::V1::ContainerStateRunning) }
+        def running(&block); end
 
         sig { returns(T::Boolean) }
         def running_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::ContainerStateTerminated) }
-        def terminated; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ContainerStateTerminated).void)).returns(KubeDSL::DSL::V1::ContainerStateTerminated) }
+        def terminated(&block); end
 
         sig { returns(T::Boolean) }
         def terminated_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::ContainerStateWaiting) }
-        def waiting; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ContainerStateWaiting).void)).returns(KubeDSL::DSL::V1::ContainerStateWaiting) }
+        def waiting(&block); end
 
         sig { returns(T::Boolean) }
         def waiting_present?; end
@@ -11810,8 +11810,8 @@ module KubeDSL
         sig { params(val: T.nilable(String)).returns(String) }
         def image_id(val = nil); end
 
-        sig { returns(KubeDSL::DSL::V1::ContainerState) }
-        def last_state; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ContainerState).void)).returns(KubeDSL::DSL::V1::ContainerState) }
+        def last_state(&block); end
 
         sig { returns(T::Boolean) }
         def last_state_present?; end
@@ -11828,8 +11828,8 @@ module KubeDSL
         sig { params(val: T.nilable(T::Boolean)).returns(T::Boolean) }
         def started(val = nil); end
 
-        sig { returns(KubeDSL::DSL::V1::ContainerState) }
-        def state; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ContainerState).void)).returns(KubeDSL::DSL::V1::ContainerState) }
+        def state(&block); end
 
         sig { returns(T::Boolean) }
         def state_present?; end
@@ -11846,14 +11846,14 @@ module KubeDSL
         sig { returns(Symbol) }
         def kind_sym; end
 
-        sig { returns(KubeDSL::DSL::V1::SecretReference) }
-        def controller_expand_secret_ref; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::SecretReference).void)).returns(KubeDSL::DSL::V1::SecretReference) }
+        def controller_expand_secret_ref(&block); end
 
         sig { returns(T::Boolean) }
         def controller_expand_secret_ref_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::SecretReference) }
-        def controller_publish_secret_ref; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::SecretReference).void)).returns(KubeDSL::DSL::V1::SecretReference) }
+        def controller_publish_secret_ref(&block); end
 
         sig { returns(T::Boolean) }
         def controller_publish_secret_ref_present?; end
@@ -11864,14 +11864,14 @@ module KubeDSL
         sig { params(val: T.nilable(String)).returns(String) }
         def fs_type(val = nil); end
 
-        sig { returns(KubeDSL::DSL::V1::SecretReference) }
-        def node_publish_secret_ref; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::SecretReference).void)).returns(KubeDSL::DSL::V1::SecretReference) }
+        def node_publish_secret_ref(&block); end
 
         sig { returns(T::Boolean) }
         def node_publish_secret_ref_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::SecretReference) }
-        def node_stage_secret_ref; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::SecretReference).void)).returns(KubeDSL::DSL::V1::SecretReference) }
+        def node_stage_secret_ref(&block); end
 
         sig { returns(T::Boolean) }
         def node_stage_secret_ref_present?; end
@@ -11879,7 +11879,7 @@ module KubeDSL
         sig { params(val: T.nilable(T::Boolean)).returns(T::Boolean) }
         def read_only(val = nil); end
 
-        sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+        sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
         def volume_attributes(&block); end
 
         sig { params(val: T.nilable(String)).returns(String) }
@@ -11903,8 +11903,8 @@ module KubeDSL
         sig { params(val: T.nilable(String)).returns(String) }
         def fs_type(val = nil); end
 
-        sig { returns(KubeDSL::DSL::V1::LocalObjectReference) }
-        def node_publish_secret_ref; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::LocalObjectReference).void)).returns(KubeDSL::DSL::V1::LocalObjectReference) }
+        def node_publish_secret_ref(&block); end
 
         sig { returns(T::Boolean) }
         def node_publish_secret_ref_present?; end
@@ -11912,7 +11912,7 @@ module KubeDSL
         sig { params(val: T.nilable(T::Boolean)).returns(T::Boolean) }
         def read_only(val = nil); end
 
-        sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+        sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
         def volume_attributes(&block); end
       end
 
@@ -11957,8 +11957,8 @@ module KubeDSL
         sig { returns(Symbol) }
         def kind_sym; end
 
-        sig { returns(KubeDSL::DSL::V1::ObjectFieldSelector) }
-        def field_ref; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ObjectFieldSelector).void)).returns(KubeDSL::DSL::V1::ObjectFieldSelector) }
+        def field_ref(&block); end
 
         sig { returns(T::Boolean) }
         def field_ref_present?; end
@@ -11969,8 +11969,8 @@ module KubeDSL
         sig { params(val: T.nilable(String)).returns(String) }
         def path(val = nil); end
 
-        sig { returns(KubeDSL::DSL::V1::ResourceFieldSelector) }
-        def resource_field_ref; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ResourceFieldSelector).void)).returns(KubeDSL::DSL::V1::ResourceFieldSelector) }
+        def resource_field_ref(&block); end
 
         sig { returns(T::Boolean) }
         def resource_field_ref_present?; end
@@ -12032,8 +12032,8 @@ module KubeDSL
         sig { params(val: T.nilable(String)).returns(String) }
         def node_name(val = nil); end
 
-        sig { returns(KubeDSL::DSL::V1::ObjectReference) }
-        def target_ref; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ObjectReference).void)).returns(KubeDSL::DSL::V1::ObjectReference) }
+        def target_ref(&block); end
 
         sig { returns(T::Boolean) }
         def target_ref_present?; end
@@ -12095,8 +12095,8 @@ module KubeDSL
         sig { returns(Symbol) }
         def kind_sym; end
 
-        sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-        def metadata; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+        def metadata(&block); end
 
         sig { returns(T::Boolean) }
         def metadata_present?; end
@@ -12119,8 +12119,8 @@ module KubeDSL
         sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::V1::Endpoints))).returns(T::Array[KubeDSL::DSL::V1::Endpoints]) }
         def items(elem_name = nil, &block); end
 
-        sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-        def metadata; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+        def metadata(&block); end
 
         sig { returns(T::Boolean) }
         def metadata_present?; end
@@ -12137,8 +12137,8 @@ module KubeDSL
         sig { returns(Symbol) }
         def kind_sym; end
 
-        sig { returns(KubeDSL::DSL::V1::ConfigMapEnvSource) }
-        def config_map_ref; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ConfigMapEnvSource).void)).returns(KubeDSL::DSL::V1::ConfigMapEnvSource) }
+        def config_map_ref(&block); end
 
         sig { returns(T::Boolean) }
         def config_map_ref_present?; end
@@ -12146,8 +12146,8 @@ module KubeDSL
         sig { params(val: T.nilable(String)).returns(String) }
         def prefix(val = nil); end
 
-        sig { returns(KubeDSL::DSL::V1::SecretEnvSource) }
-        def secret_ref; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::SecretEnvSource).void)).returns(KubeDSL::DSL::V1::SecretEnvSource) }
+        def secret_ref(&block); end
 
         sig { returns(T::Boolean) }
         def secret_ref_present?; end
@@ -12170,8 +12170,8 @@ module KubeDSL
         sig { params(val: T.nilable(String)).returns(String) }
         def value(val = nil); end
 
-        sig { returns(KubeDSL::DSL::V1::EnvVarSource) }
-        def value_from; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::EnvVarSource).void)).returns(KubeDSL::DSL::V1::EnvVarSource) }
+        def value_from(&block); end
 
         sig { returns(T::Boolean) }
         def value_from_present?; end
@@ -12188,26 +12188,26 @@ module KubeDSL
         sig { returns(Symbol) }
         def kind_sym; end
 
-        sig { returns(KubeDSL::DSL::V1::ConfigMapKeySelector) }
-        def config_map_key_ref; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ConfigMapKeySelector).void)).returns(KubeDSL::DSL::V1::ConfigMapKeySelector) }
+        def config_map_key_ref(&block); end
 
         sig { returns(T::Boolean) }
         def config_map_key_ref_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::ObjectFieldSelector) }
-        def field_ref; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ObjectFieldSelector).void)).returns(KubeDSL::DSL::V1::ObjectFieldSelector) }
+        def field_ref(&block); end
 
         sig { returns(T::Boolean) }
         def field_ref_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::ResourceFieldSelector) }
-        def resource_field_ref; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ResourceFieldSelector).void)).returns(KubeDSL::DSL::V1::ResourceFieldSelector) }
+        def resource_field_ref(&block); end
 
         sig { returns(T::Boolean) }
         def resource_field_ref_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::SecretKeySelector) }
-        def secret_key_ref; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::SecretKeySelector).void)).returns(KubeDSL::DSL::V1::SecretKeySelector) }
+        def secret_key_ref(&block); end
 
         sig { returns(T::Boolean) }
         def secret_key_ref_present?; end
@@ -12242,14 +12242,14 @@ module KubeDSL
         sig { params(val: T.nilable(String)).returns(String) }
         def image_pull_policy(val = nil); end
 
-        sig { returns(KubeDSL::DSL::V1::Lifecycle) }
-        def lifecycle; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::Lifecycle).void)).returns(KubeDSL::DSL::V1::Lifecycle) }
+        def lifecycle(&block); end
 
         sig { returns(T::Boolean) }
         def lifecycle_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::Probe) }
-        def liveness_probe; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::Probe).void)).returns(KubeDSL::DSL::V1::Probe) }
+        def liveness_probe(&block); end
 
         sig { returns(T::Boolean) }
         def liveness_probe_present?; end
@@ -12260,26 +12260,26 @@ module KubeDSL
         sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::V1::ContainerPort))).returns(T::Array[KubeDSL::DSL::V1::ContainerPort]) }
         def ports(elem_name = nil, &block); end
 
-        sig { returns(KubeDSL::DSL::V1::Probe) }
-        def readiness_probe; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::Probe).void)).returns(KubeDSL::DSL::V1::Probe) }
+        def readiness_probe(&block); end
 
         sig { returns(T::Boolean) }
         def readiness_probe_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::ResourceRequirements) }
-        def resources; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ResourceRequirements).void)).returns(KubeDSL::DSL::V1::ResourceRequirements) }
+        def resources(&block); end
 
         sig { returns(T::Boolean) }
         def resources_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::SecurityContext) }
-        def security_context; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::SecurityContext).void)).returns(KubeDSL::DSL::V1::SecurityContext) }
+        def security_context(&block); end
 
         sig { returns(T::Boolean) }
         def security_context_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::Probe) }
-        def startup_probe; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::Probe).void)).returns(KubeDSL::DSL::V1::Probe) }
+        def startup_probe(&block); end
 
         sig { returns(T::Boolean) }
         def startup_probe_present?; end
@@ -12323,8 +12323,8 @@ module KubeDSL
         sig { returns(Symbol) }
         def kind_sym; end
 
-        sig { returns(KubeDSL::DSL::V1::PersistentVolumeClaimTemplate) }
-        def volume_claim_template; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PersistentVolumeClaimTemplate).void)).returns(KubeDSL::DSL::V1::PersistentVolumeClaimTemplate) }
+        def volume_claim_template(&block); end
 
         sig { returns(T::Boolean) }
         def volume_claim_template_present?; end
@@ -12353,8 +12353,8 @@ module KubeDSL
         sig { params(val: T.nilable(String)).returns(String) }
         def first_timestamp(val = nil); end
 
-        sig { returns(KubeDSL::DSL::V1::ObjectReference) }
-        def involved_object; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ObjectReference).void)).returns(KubeDSL::DSL::V1::ObjectReference) }
+        def involved_object(&block); end
 
         sig { returns(T::Boolean) }
         def involved_object_present?; end
@@ -12365,8 +12365,8 @@ module KubeDSL
         sig { params(val: T.nilable(String)).returns(String) }
         def message(val = nil); end
 
-        sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-        def metadata; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+        def metadata(&block); end
 
         sig { returns(T::Boolean) }
         def metadata_present?; end
@@ -12374,8 +12374,8 @@ module KubeDSL
         sig { params(val: T.nilable(String)).returns(String) }
         def reason(val = nil); end
 
-        sig { returns(KubeDSL::DSL::V1::ObjectReference) }
-        def related; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ObjectReference).void)).returns(KubeDSL::DSL::V1::ObjectReference) }
+        def related(&block); end
 
         sig { returns(T::Boolean) }
         def related_present?; end
@@ -12386,14 +12386,14 @@ module KubeDSL
         sig { params(val: T.nilable(String)).returns(String) }
         def reporting_instance(val = nil); end
 
-        sig { returns(KubeDSL::DSL::V1::EventSeries) }
-        def series; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::EventSeries).void)).returns(KubeDSL::DSL::V1::EventSeries) }
+        def series(&block); end
 
         sig { returns(T::Boolean) }
         def series_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::EventSource) }
-        def source; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::EventSource).void)).returns(KubeDSL::DSL::V1::EventSource) }
+        def source(&block); end
 
         sig { returns(T::Boolean) }
         def source_present?; end
@@ -12416,8 +12416,8 @@ module KubeDSL
         sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::V1::Event))).returns(T::Array[KubeDSL::DSL::V1::Event]) }
         def items(elem_name = nil, &block); end
 
-        sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-        def metadata; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+        def metadata(&block); end
 
         sig { returns(T::Boolean) }
         def metadata_present?; end
@@ -12518,14 +12518,14 @@ module KubeDSL
         sig { params(val: T.nilable(String)).returns(String) }
         def fs_type(val = nil); end
 
-        sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+        sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
         def options(&block); end
 
         sig { params(val: T.nilable(T::Boolean)).returns(T::Boolean) }
         def read_only(val = nil); end
 
-        sig { returns(KubeDSL::DSL::V1::SecretReference) }
-        def secret_ref; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::SecretReference).void)).returns(KubeDSL::DSL::V1::SecretReference) }
+        def secret_ref(&block); end
 
         sig { returns(T::Boolean) }
         def secret_ref_present?; end
@@ -12548,14 +12548,14 @@ module KubeDSL
         sig { params(val: T.nilable(String)).returns(String) }
         def fs_type(val = nil); end
 
-        sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+        sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
         def options(&block); end
 
         sig { params(val: T.nilable(T::Boolean)).returns(T::Boolean) }
         def read_only(val = nil); end
 
-        sig { returns(KubeDSL::DSL::V1::LocalObjectReference) }
-        def secret_ref; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::LocalObjectReference).void)).returns(KubeDSL::DSL::V1::LocalObjectReference) }
+        def secret_ref(&block); end
 
         sig { returns(T::Boolean) }
         def secret_ref_present?; end
@@ -12806,8 +12806,8 @@ module KubeDSL
         sig { params(val: T.nilable(T::Boolean)).returns(T::Boolean) }
         def read_only(val = nil); end
 
-        sig { returns(KubeDSL::DSL::V1::SecretReference) }
-        def secret_ref; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::SecretReference).void)).returns(KubeDSL::DSL::V1::SecretReference) }
+        def secret_ref(&block); end
 
         sig { returns(T::Boolean) }
         def secret_ref_present?; end
@@ -12854,8 +12854,8 @@ module KubeDSL
         sig { params(val: T.nilable(T::Boolean)).returns(T::Boolean) }
         def read_only(val = nil); end
 
-        sig { returns(KubeDSL::DSL::V1::LocalObjectReference) }
-        def secret_ref; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::LocalObjectReference).void)).returns(KubeDSL::DSL::V1::LocalObjectReference) }
+        def secret_ref(&block); end
 
         sig { returns(T::Boolean) }
         def secret_ref_present?; end
@@ -12896,14 +12896,14 @@ module KubeDSL
         sig { returns(Symbol) }
         def kind_sym; end
 
-        sig { returns(KubeDSL::DSL::V1::LifecycleHandler) }
-        def post_start; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::LifecycleHandler).void)).returns(KubeDSL::DSL::V1::LifecycleHandler) }
+        def post_start(&block); end
 
         sig { returns(T::Boolean) }
         def post_start_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::LifecycleHandler) }
-        def pre_stop; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::LifecycleHandler).void)).returns(KubeDSL::DSL::V1::LifecycleHandler) }
+        def pre_stop(&block); end
 
         sig { returns(T::Boolean) }
         def pre_stop_present?; end
@@ -12920,20 +12920,20 @@ module KubeDSL
         sig { returns(Symbol) }
         def kind_sym; end
 
-        sig { returns(KubeDSL::DSL::V1::ExecAction) }
-        def exec; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ExecAction).void)).returns(KubeDSL::DSL::V1::ExecAction) }
+        def exec(&block); end
 
         sig { returns(T::Boolean) }
         def exec_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::HTTPGetAction) }
-        def http_get; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::HTTPGetAction).void)).returns(KubeDSL::DSL::V1::HTTPGetAction) }
+        def http_get(&block); end
 
         sig { returns(T::Boolean) }
         def http_get_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::TCPSocketAction) }
-        def tcp_socket; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::TCPSocketAction).void)).returns(KubeDSL::DSL::V1::TCPSocketAction) }
+        def tcp_socket(&block); end
 
         sig { returns(T::Boolean) }
         def tcp_socket_present?; end
@@ -12950,14 +12950,14 @@ module KubeDSL
         sig { returns(Symbol) }
         def kind_sym; end
 
-        sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-        def metadata; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+        def metadata(&block); end
 
         sig { returns(T::Boolean) }
         def metadata_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::LimitRangeSpec) }
-        def spec; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::LimitRangeSpec).void)).returns(KubeDSL::DSL::V1::LimitRangeSpec) }
+        def spec(&block); end
 
         sig { returns(T::Boolean) }
         def spec_present?; end
@@ -12974,19 +12974,19 @@ module KubeDSL
         sig { returns(Symbol) }
         def kind_sym; end
 
-        sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+        sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
         def default(&block); end
 
-        sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+        sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
         def default_request(&block); end
 
-        sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+        sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
         def max(&block); end
 
-        sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+        sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
         def max_limit_request_ratio(&block); end
 
-        sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+        sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
         def min(&block); end
 
         sig { params(val: T.nilable(String)).returns(String) }
@@ -13007,8 +13007,8 @@ module KubeDSL
         sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::V1::LimitRange))).returns(T::Array[KubeDSL::DSL::V1::LimitRange]) }
         def items(elem_name = nil, &block); end
 
-        sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-        def metadata; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+        def metadata(&block); end
 
         sig { returns(T::Boolean) }
         def metadata_present?; end
@@ -13109,20 +13109,20 @@ module KubeDSL
         sig { returns(Symbol) }
         def kind_sym; end
 
-        sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-        def metadata; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+        def metadata(&block); end
 
         sig { returns(T::Boolean) }
         def metadata_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::NamespaceSpec) }
-        def spec; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::NamespaceSpec).void)).returns(KubeDSL::DSL::V1::NamespaceSpec) }
+        def spec(&block); end
 
         sig { returns(T::Boolean) }
         def spec_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::NamespaceStatus) }
-        def status; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::NamespaceStatus).void)).returns(KubeDSL::DSL::V1::NamespaceStatus) }
+        def status(&block); end
 
         sig { returns(T::Boolean) }
         def status_present?; end
@@ -13169,8 +13169,8 @@ module KubeDSL
         sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::V1::Namespace))).returns(T::Array[KubeDSL::DSL::V1::Namespace]) }
         def items(elem_name = nil, &block); end
 
-        sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-        def metadata; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+        def metadata(&block); end
 
         sig { returns(T::Boolean) }
         def metadata_present?; end
@@ -13241,20 +13241,20 @@ module KubeDSL
         sig { returns(Symbol) }
         def kind_sym; end
 
-        sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-        def metadata; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+        def metadata(&block); end
 
         sig { returns(T::Boolean) }
         def metadata_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::NodeSpec) }
-        def spec; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::NodeSpec).void)).returns(KubeDSL::DSL::V1::NodeSpec) }
+        def spec(&block); end
 
         sig { returns(T::Boolean) }
         def spec_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::NodeStatus) }
-        def status; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::NodeStatus).void)).returns(KubeDSL::DSL::V1::NodeStatus) }
+        def status(&block); end
 
         sig { returns(T::Boolean) }
         def status_present?; end
@@ -13292,8 +13292,8 @@ module KubeDSL
         sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::V1::PreferredSchedulingTerm))).returns(T::Array[KubeDSL::DSL::V1::PreferredSchedulingTerm]) }
         def preferred_during_scheduling_ignored_during_executions(elem_name = nil, &block); end
 
-        sig { returns(KubeDSL::DSL::V1::NodeSelector) }
-        def required_during_scheduling_ignored_during_execution; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::NodeSelector).void)).returns(KubeDSL::DSL::V1::NodeSelector) }
+        def required_during_scheduling_ignored_during_execution(&block); end
 
         sig { returns(T::Boolean) }
         def required_during_scheduling_ignored_during_execution_present?; end
@@ -13340,8 +13340,8 @@ module KubeDSL
         sig { returns(Symbol) }
         def kind_sym; end
 
-        sig { returns(KubeDSL::DSL::V1::ConfigMapNodeConfigSource) }
-        def config_map; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ConfigMapNodeConfigSource).void)).returns(KubeDSL::DSL::V1::ConfigMapNodeConfigSource) }
+        def config_map(&block); end
 
         sig { returns(T::Boolean) }
         def config_map_present?; end
@@ -13358,14 +13358,14 @@ module KubeDSL
         sig { returns(Symbol) }
         def kind_sym; end
 
-        sig { returns(KubeDSL::DSL::V1::NodeConfigSource) }
-        def active; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::NodeConfigSource).void)).returns(KubeDSL::DSL::V1::NodeConfigSource) }
+        def active(&block); end
 
         sig { returns(T::Boolean) }
         def active_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::NodeConfigSource) }
-        def assigned; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::NodeConfigSource).void)).returns(KubeDSL::DSL::V1::NodeConfigSource) }
+        def assigned(&block); end
 
         sig { returns(T::Boolean) }
         def assigned_present?; end
@@ -13373,8 +13373,8 @@ module KubeDSL
         sig { params(val: T.nilable(String)).returns(String) }
         def error(val = nil); end
 
-        sig { returns(KubeDSL::DSL::V1::NodeConfigSource) }
-        def last_known_good; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::NodeConfigSource).void)).returns(KubeDSL::DSL::V1::NodeConfigSource) }
+        def last_known_good(&block); end
 
         sig { returns(T::Boolean) }
         def last_known_good_present?; end
@@ -13391,8 +13391,8 @@ module KubeDSL
         sig { returns(Symbol) }
         def kind_sym; end
 
-        sig { returns(KubeDSL::DSL::V1::DaemonEndpoint) }
-        def kubelet_endpoint; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::DaemonEndpoint).void)).returns(KubeDSL::DSL::V1::DaemonEndpoint) }
+        def kubelet_endpoint(&block); end
 
         sig { returns(T::Boolean) }
         def kubelet_endpoint_present?; end
@@ -13412,8 +13412,8 @@ module KubeDSL
         sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::V1::Node))).returns(T::Array[KubeDSL::DSL::V1::Node]) }
         def items(elem_name = nil, &block); end
 
-        sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-        def metadata; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+        def metadata(&block); end
 
         sig { returns(T::Boolean) }
         def metadata_present?; end
@@ -13484,8 +13484,8 @@ module KubeDSL
         sig { returns(Symbol) }
         def kind_sym; end
 
-        sig { returns(KubeDSL::DSL::V1::NodeConfigSource) }
-        def config_source; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::NodeConfigSource).void)).returns(KubeDSL::DSL::V1::NodeConfigSource) }
+        def config_source(&block); end
 
         sig { returns(T::Boolean) }
         def config_source_present?; end
@@ -13523,23 +13523,23 @@ module KubeDSL
         sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::V1::NodeAddress))).returns(T::Array[KubeDSL::DSL::V1::NodeAddress]) }
         def addresses(elem_name = nil, &block); end
 
-        sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+        sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
         def allocatable(&block); end
 
-        sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+        sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
         def capacity(&block); end
 
         sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::V1::NodeCondition))).returns(T::Array[KubeDSL::DSL::V1::NodeCondition]) }
         def conditions(elem_name = nil, &block); end
 
-        sig { returns(KubeDSL::DSL::V1::NodeConfigStatus) }
-        def config; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::NodeConfigStatus).void)).returns(KubeDSL::DSL::V1::NodeConfigStatus) }
+        def config(&block); end
 
         sig { returns(T::Boolean) }
         def config_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::NodeDaemonEndpoints) }
-        def daemon_endpoints; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::NodeDaemonEndpoints).void)).returns(KubeDSL::DSL::V1::NodeDaemonEndpoints) }
+        def daemon_endpoints(&block); end
 
         sig { returns(T::Boolean) }
         def daemon_endpoints_present?; end
@@ -13547,8 +13547,8 @@ module KubeDSL
         sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::V1::ContainerImage))).returns(T::Array[KubeDSL::DSL::V1::ContainerImage]) }
         def images(elem_name = nil, &block); end
 
-        sig { returns(KubeDSL::DSL::V1::NodeSystemInfo) }
-        def node_info; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::NodeSystemInfo).void)).returns(KubeDSL::DSL::V1::NodeSystemInfo) }
+        def node_info(&block); end
 
         sig { returns(T::Boolean) }
         def node_info_present?; end
@@ -13667,20 +13667,20 @@ module KubeDSL
         sig { returns(Symbol) }
         def kind_sym; end
 
-        sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-        def metadata; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+        def metadata(&block); end
 
         sig { returns(T::Boolean) }
         def metadata_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::PersistentVolumeSpec) }
-        def spec; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PersistentVolumeSpec).void)).returns(KubeDSL::DSL::V1::PersistentVolumeSpec) }
+        def spec(&block); end
 
         sig { returns(T::Boolean) }
         def spec_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::PersistentVolumeStatus) }
-        def status; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PersistentVolumeStatus).void)).returns(KubeDSL::DSL::V1::PersistentVolumeStatus) }
+        def status(&block); end
 
         sig { returns(T::Boolean) }
         def status_present?; end
@@ -13697,20 +13697,20 @@ module KubeDSL
         sig { returns(Symbol) }
         def kind_sym; end
 
-        sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-        def metadata; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+        def metadata(&block); end
 
         sig { returns(T::Boolean) }
         def metadata_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::PersistentVolumeClaimSpec) }
-        def spec; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PersistentVolumeClaimSpec).void)).returns(KubeDSL::DSL::V1::PersistentVolumeClaimSpec) }
+        def spec(&block); end
 
         sig { returns(T::Boolean) }
         def spec_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::PersistentVolumeClaimStatus) }
-        def status; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PersistentVolumeClaimStatus).void)).returns(KubeDSL::DSL::V1::PersistentVolumeClaimStatus) }
+        def status(&block); end
 
         sig { returns(T::Boolean) }
         def status_present?; end
@@ -13760,8 +13760,8 @@ module KubeDSL
         sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::V1::PersistentVolumeClaim))).returns(T::Array[KubeDSL::DSL::V1::PersistentVolumeClaim]) }
         def items(elem_name = nil, &block); end
 
-        sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-        def metadata; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+        def metadata(&block); end
 
         sig { returns(T::Boolean) }
         def metadata_present?; end
@@ -13781,26 +13781,26 @@ module KubeDSL
         sig { params(val: T.nilable(String)).returns(String) }
         def access_modes(val = nil); end
 
-        sig { returns(KubeDSL::DSL::V1::TypedLocalObjectReference) }
-        def data_source; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::TypedLocalObjectReference).void)).returns(KubeDSL::DSL::V1::TypedLocalObjectReference) }
+        def data_source(&block); end
 
         sig { returns(T::Boolean) }
         def data_source_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::TypedLocalObjectReference) }
-        def data_source_ref; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::TypedLocalObjectReference).void)).returns(KubeDSL::DSL::V1::TypedLocalObjectReference) }
+        def data_source_ref(&block); end
 
         sig { returns(T::Boolean) }
         def data_source_ref_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::ResourceRequirements) }
-        def resources; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ResourceRequirements).void)).returns(KubeDSL::DSL::V1::ResourceRequirements) }
+        def resources(&block); end
 
         sig { returns(T::Boolean) }
         def resources_present?; end
 
-        sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-        def selector; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+        def selector(&block); end
 
         sig { returns(T::Boolean) }
         def selector_present?; end
@@ -13829,10 +13829,10 @@ module KubeDSL
         sig { params(val: T.nilable(String)).returns(String) }
         def access_modes(val = nil); end
 
-        sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+        sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
         def allocated_resources(&block); end
 
-        sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+        sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
         def capacity(&block); end
 
         sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::V1::PersistentVolumeClaimCondition))).returns(T::Array[KubeDSL::DSL::V1::PersistentVolumeClaimCondition]) }
@@ -13856,14 +13856,14 @@ module KubeDSL
         sig { returns(Symbol) }
         def kind_sym; end
 
-        sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-        def metadata; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+        def metadata(&block); end
 
         sig { returns(T::Boolean) }
         def metadata_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::PersistentVolumeClaimSpec) }
-        def spec; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PersistentVolumeClaimSpec).void)).returns(KubeDSL::DSL::V1::PersistentVolumeClaimSpec) }
+        def spec(&block); end
 
         sig { returns(T::Boolean) }
         def spec_present?; end
@@ -13901,8 +13901,8 @@ module KubeDSL
         sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::V1::PersistentVolume))).returns(T::Array[KubeDSL::DSL::V1::PersistentVolume]) }
         def items(elem_name = nil, &block); end
 
-        sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-        def metadata; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+        def metadata(&block); end
 
         sig { returns(T::Boolean) }
         def metadata_present?; end
@@ -13922,95 +13922,95 @@ module KubeDSL
         sig { params(val: T.nilable(String)).returns(String) }
         def access_modes(val = nil); end
 
-        sig { returns(KubeDSL::DSL::V1::AWSElasticBlockStoreVolumeSource) }
-        def aws_elastic_block_store; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::AWSElasticBlockStoreVolumeSource).void)).returns(KubeDSL::DSL::V1::AWSElasticBlockStoreVolumeSource) }
+        def aws_elastic_block_store(&block); end
 
         sig { returns(T::Boolean) }
         def aws_elastic_block_store_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::AzureDiskVolumeSource) }
-        def azure_disk; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::AzureDiskVolumeSource).void)).returns(KubeDSL::DSL::V1::AzureDiskVolumeSource) }
+        def azure_disk(&block); end
 
         sig { returns(T::Boolean) }
         def azure_disk_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::AzureFilePersistentVolumeSource) }
-        def azure_file; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::AzureFilePersistentVolumeSource).void)).returns(KubeDSL::DSL::V1::AzureFilePersistentVolumeSource) }
+        def azure_file(&block); end
 
         sig { returns(T::Boolean) }
         def azure_file_present?; end
 
-        sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+        sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
         def capacity(&block); end
 
-        sig { returns(KubeDSL::DSL::V1::CephFSPersistentVolumeSource) }
-        def cephfs; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::CephFSPersistentVolumeSource).void)).returns(KubeDSL::DSL::V1::CephFSPersistentVolumeSource) }
+        def cephfs(&block); end
 
         sig { returns(T::Boolean) }
         def cephfs_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::CinderPersistentVolumeSource) }
-        def cinder; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::CinderPersistentVolumeSource).void)).returns(KubeDSL::DSL::V1::CinderPersistentVolumeSource) }
+        def cinder(&block); end
 
         sig { returns(T::Boolean) }
         def cinder_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::ObjectReference) }
-        def claim_ref; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ObjectReference).void)).returns(KubeDSL::DSL::V1::ObjectReference) }
+        def claim_ref(&block); end
 
         sig { returns(T::Boolean) }
         def claim_ref_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::CSIPersistentVolumeSource) }
-        def csi; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::CSIPersistentVolumeSource).void)).returns(KubeDSL::DSL::V1::CSIPersistentVolumeSource) }
+        def csi(&block); end
 
         sig { returns(T::Boolean) }
         def csi_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::FCVolumeSource) }
-        def fc; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::FCVolumeSource).void)).returns(KubeDSL::DSL::V1::FCVolumeSource) }
+        def fc(&block); end
 
         sig { returns(T::Boolean) }
         def fc_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::FlexPersistentVolumeSource) }
-        def flex_volume; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::FlexPersistentVolumeSource).void)).returns(KubeDSL::DSL::V1::FlexPersistentVolumeSource) }
+        def flex_volume(&block); end
 
         sig { returns(T::Boolean) }
         def flex_volume_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::FlockerVolumeSource) }
-        def flocker; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::FlockerVolumeSource).void)).returns(KubeDSL::DSL::V1::FlockerVolumeSource) }
+        def flocker(&block); end
 
         sig { returns(T::Boolean) }
         def flocker_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::GCEPersistentDiskVolumeSource) }
-        def gce_persistent_disk; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::GCEPersistentDiskVolumeSource).void)).returns(KubeDSL::DSL::V1::GCEPersistentDiskVolumeSource) }
+        def gce_persistent_disk(&block); end
 
         sig { returns(T::Boolean) }
         def gce_persistent_disk_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::GlusterfsPersistentVolumeSource) }
-        def glusterfs; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::GlusterfsPersistentVolumeSource).void)).returns(KubeDSL::DSL::V1::GlusterfsPersistentVolumeSource) }
+        def glusterfs(&block); end
 
         sig { returns(T::Boolean) }
         def glusterfs_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::HostPathVolumeSource) }
-        def host_path; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::HostPathVolumeSource).void)).returns(KubeDSL::DSL::V1::HostPathVolumeSource) }
+        def host_path(&block); end
 
         sig { returns(T::Boolean) }
         def host_path_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::ISCSIPersistentVolumeSource) }
-        def iscsi; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ISCSIPersistentVolumeSource).void)).returns(KubeDSL::DSL::V1::ISCSIPersistentVolumeSource) }
+        def iscsi(&block); end
 
         sig { returns(T::Boolean) }
         def iscsi_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::LocalVolumeSource) }
-        def local; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::LocalVolumeSource).void)).returns(KubeDSL::DSL::V1::LocalVolumeSource) }
+        def local(&block); end
 
         sig { returns(T::Boolean) }
         def local_present?; end
@@ -14018,14 +14018,14 @@ module KubeDSL
         sig { params(val: T.nilable(String)).returns(String) }
         def mount_options(val = nil); end
 
-        sig { returns(KubeDSL::DSL::V1::NFSVolumeSource) }
-        def nfs; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::NFSVolumeSource).void)).returns(KubeDSL::DSL::V1::NFSVolumeSource) }
+        def nfs(&block); end
 
         sig { returns(T::Boolean) }
         def nfs_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::VolumeNodeAffinity) }
-        def node_affinity; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::VolumeNodeAffinity).void)).returns(KubeDSL::DSL::V1::VolumeNodeAffinity) }
+        def node_affinity(&block); end
 
         sig { returns(T::Boolean) }
         def node_affinity_present?; end
@@ -14033,32 +14033,32 @@ module KubeDSL
         sig { params(val: T.nilable(String)).returns(String) }
         def persistent_volume_reclaim_policy(val = nil); end
 
-        sig { returns(KubeDSL::DSL::V1::PhotonPersistentDiskVolumeSource) }
-        def photon_persistent_disk; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PhotonPersistentDiskVolumeSource).void)).returns(KubeDSL::DSL::V1::PhotonPersistentDiskVolumeSource) }
+        def photon_persistent_disk(&block); end
 
         sig { returns(T::Boolean) }
         def photon_persistent_disk_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::PortworxVolumeSource) }
-        def portworx_volume; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PortworxVolumeSource).void)).returns(KubeDSL::DSL::V1::PortworxVolumeSource) }
+        def portworx_volume(&block); end
 
         sig { returns(T::Boolean) }
         def portworx_volume_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::QuobyteVolumeSource) }
-        def quobyte; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::QuobyteVolumeSource).void)).returns(KubeDSL::DSL::V1::QuobyteVolumeSource) }
+        def quobyte(&block); end
 
         sig { returns(T::Boolean) }
         def quobyte_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::RBDPersistentVolumeSource) }
-        def rbd; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::RBDPersistentVolumeSource).void)).returns(KubeDSL::DSL::V1::RBDPersistentVolumeSource) }
+        def rbd(&block); end
 
         sig { returns(T::Boolean) }
         def rbd_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::ScaleIOPersistentVolumeSource) }
-        def scale_io; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ScaleIOPersistentVolumeSource).void)).returns(KubeDSL::DSL::V1::ScaleIOPersistentVolumeSource) }
+        def scale_io(&block); end
 
         sig { returns(T::Boolean) }
         def scale_io_present?; end
@@ -14066,8 +14066,8 @@ module KubeDSL
         sig { params(val: T.nilable(String)).returns(String) }
         def storage_class_name(val = nil); end
 
-        sig { returns(KubeDSL::DSL::V1::StorageOSPersistentVolumeSource) }
-        def storageos; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::StorageOSPersistentVolumeSource).void)).returns(KubeDSL::DSL::V1::StorageOSPersistentVolumeSource) }
+        def storageos(&block); end
 
         sig { returns(T::Boolean) }
         def storageos_present?; end
@@ -14075,8 +14075,8 @@ module KubeDSL
         sig { params(val: T.nilable(String)).returns(String) }
         def volume_mode(val = nil); end
 
-        sig { returns(KubeDSL::DSL::V1::VsphereVirtualDiskVolumeSource) }
-        def vsphere_volume; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::VsphereVirtualDiskVolumeSource).void)).returns(KubeDSL::DSL::V1::VsphereVirtualDiskVolumeSource) }
+        def vsphere_volume(&block); end
 
         sig { returns(T::Boolean) }
         def vsphere_volume_present?; end
@@ -14132,20 +14132,20 @@ module KubeDSL
         sig { returns(Symbol) }
         def kind_sym; end
 
-        sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-        def metadata; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+        def metadata(&block); end
 
         sig { returns(T::Boolean) }
         def metadata_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::PodSpec) }
-        def spec; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PodSpec).void)).returns(KubeDSL::DSL::V1::PodSpec) }
+        def spec(&block); end
 
         sig { returns(T::Boolean) }
         def spec_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::PodStatus) }
-        def status; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PodStatus).void)).returns(KubeDSL::DSL::V1::PodStatus) }
+        def status(&block); end
 
         sig { returns(T::Boolean) }
         def status_present?; end
@@ -14180,14 +14180,14 @@ module KubeDSL
         sig { returns(Symbol) }
         def kind_sym; end
 
-        sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-        def label_selector; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+        def label_selector(&block); end
 
         sig { returns(T::Boolean) }
         def label_selector_present?; end
 
-        sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-        def namespace_selector; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+        def namespace_selector(&block); end
 
         sig { returns(T::Boolean) }
         def namespace_selector_present?; end
@@ -14315,8 +14315,8 @@ module KubeDSL
         sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::V1::Pod))).returns(T::Array[KubeDSL::DSL::V1::Pod]) }
         def items(elem_name = nil, &block); end
 
-        sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-        def metadata; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+        def metadata(&block); end
 
         sig { returns(T::Boolean) }
         def metadata_present?; end
@@ -14378,14 +14378,14 @@ module KubeDSL
         sig { params(val: T.nilable(Integer)).returns(Integer) }
         def run_as_user(val = nil); end
 
-        sig { returns(KubeDSL::DSL::V1::SELinuxOptions) }
-        def se_linux_options; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::SELinuxOptions).void)).returns(KubeDSL::DSL::V1::SELinuxOptions) }
+        def se_linux_options(&block); end
 
         sig { returns(T::Boolean) }
         def se_linux_options_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::SeccompProfile) }
-        def seccomp_profile; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::SeccompProfile).void)).returns(KubeDSL::DSL::V1::SeccompProfile) }
+        def seccomp_profile(&block); end
 
         sig { returns(T::Boolean) }
         def seccomp_profile_present?; end
@@ -14396,8 +14396,8 @@ module KubeDSL
         sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::V1::Sysctl))).returns(T::Array[KubeDSL::DSL::V1::Sysctl]) }
         def sysctlses(elem_name = nil, &block); end
 
-        sig { returns(KubeDSL::DSL::V1::WindowsSecurityContextOptions) }
-        def windows_options; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::WindowsSecurityContextOptions).void)).returns(KubeDSL::DSL::V1::WindowsSecurityContextOptions) }
+        def windows_options(&block); end
 
         sig { returns(T::Boolean) }
         def windows_options_present?; end
@@ -14417,8 +14417,8 @@ module KubeDSL
         sig { params(val: T.nilable(Integer)).returns(Integer) }
         def active_deadline_seconds(val = nil); end
 
-        sig { returns(KubeDSL::DSL::V1::Affinity) }
-        def affinity; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::Affinity).void)).returns(KubeDSL::DSL::V1::Affinity) }
+        def affinity(&block); end
 
         sig { returns(T::Boolean) }
         def affinity_present?; end
@@ -14429,8 +14429,8 @@ module KubeDSL
         sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::V1::Container))).returns(T::Array[KubeDSL::DSL::V1::Container]) }
         def containers(elem_name = nil, &block); end
 
-        sig { returns(KubeDSL::DSL::V1::PodDNSConfig) }
-        def dns_config; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PodDNSConfig).void)).returns(KubeDSL::DSL::V1::PodDNSConfig) }
+        def dns_config(&block); end
 
         sig { returns(T::Boolean) }
         def dns_config_present?; end
@@ -14468,16 +14468,16 @@ module KubeDSL
         sig { params(val: T.nilable(String)).returns(String) }
         def node_name(val = nil); end
 
-        sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+        sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
         def node_selector(&block); end
 
-        sig { returns(KubeDSL::DSL::V1::PodOS) }
-        def os; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PodOS).void)).returns(KubeDSL::DSL::V1::PodOS) }
+        def os(&block); end
 
         sig { returns(T::Boolean) }
         def os_present?; end
 
-        sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+        sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
         def overhead(&block); end
 
         sig { params(val: T.nilable(String)).returns(String) }
@@ -14501,8 +14501,8 @@ module KubeDSL
         sig { params(val: T.nilable(String)).returns(String) }
         def scheduler_name(val = nil); end
 
-        sig { returns(KubeDSL::DSL::V1::PodSecurityContext) }
-        def security_context; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PodSecurityContext).void)).returns(KubeDSL::DSL::V1::PodSecurityContext) }
+        def security_context(&block); end
 
         sig { returns(T::Boolean) }
         def security_context_present?; end
@@ -14597,14 +14597,14 @@ module KubeDSL
         sig { returns(Symbol) }
         def kind_sym; end
 
-        sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-        def metadata; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+        def metadata(&block); end
 
         sig { returns(T::Boolean) }
         def metadata_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::PodTemplateSpec) }
-        def template; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PodTemplateSpec).void)).returns(KubeDSL::DSL::V1::PodTemplateSpec) }
+        def template(&block); end
 
         sig { returns(T::Boolean) }
         def template_present?; end
@@ -14624,8 +14624,8 @@ module KubeDSL
         sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::V1::PodTemplate))).returns(T::Array[KubeDSL::DSL::V1::PodTemplate]) }
         def items(elem_name = nil, &block); end
 
-        sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-        def metadata; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+        def metadata(&block); end
 
         sig { returns(T::Boolean) }
         def metadata_present?; end
@@ -14642,14 +14642,14 @@ module KubeDSL
         sig { returns(Symbol) }
         def kind_sym; end
 
-        sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-        def metadata; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+        def metadata(&block); end
 
         sig { returns(T::Boolean) }
         def metadata_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::PodSpec) }
-        def spec; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PodSpec).void)).returns(KubeDSL::DSL::V1::PodSpec) }
+        def spec(&block); end
 
         sig { returns(T::Boolean) }
         def spec_present?; end
@@ -14708,8 +14708,8 @@ module KubeDSL
         sig { returns(Symbol) }
         def kind_sym; end
 
-        sig { returns(KubeDSL::DSL::V1::NodeSelectorTerm) }
-        def preference; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::NodeSelectorTerm).void)).returns(KubeDSL::DSL::V1::NodeSelectorTerm) }
+        def preference(&block); end
 
         sig { returns(T::Boolean) }
         def preference_present?; end
@@ -14729,8 +14729,8 @@ module KubeDSL
         sig { returns(Symbol) }
         def kind_sym; end
 
-        sig { returns(KubeDSL::DSL::V1::ExecAction) }
-        def exec; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ExecAction).void)).returns(KubeDSL::DSL::V1::ExecAction) }
+        def exec(&block); end
 
         sig { returns(T::Boolean) }
         def exec_present?; end
@@ -14738,14 +14738,14 @@ module KubeDSL
         sig { params(val: T.nilable(Integer)).returns(Integer) }
         def failure_threshold(val = nil); end
 
-        sig { returns(KubeDSL::DSL::V1::GRPCAction) }
-        def grpc; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::GRPCAction).void)).returns(KubeDSL::DSL::V1::GRPCAction) }
+        def grpc(&block); end
 
         sig { returns(T::Boolean) }
         def grpc_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::HTTPGetAction) }
-        def http_get; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::HTTPGetAction).void)).returns(KubeDSL::DSL::V1::HTTPGetAction) }
+        def http_get(&block); end
 
         sig { returns(T::Boolean) }
         def http_get_present?; end
@@ -14759,8 +14759,8 @@ module KubeDSL
         sig { params(val: T.nilable(Integer)).returns(Integer) }
         def success_threshold(val = nil); end
 
-        sig { returns(KubeDSL::DSL::V1::TCPSocketAction) }
-        def tcp_socket; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::TCPSocketAction).void)).returns(KubeDSL::DSL::V1::TCPSocketAction) }
+        def tcp_socket(&block); end
 
         sig { returns(T::Boolean) }
         def tcp_socket_present?; end
@@ -14849,8 +14849,8 @@ module KubeDSL
         sig { params(val: T.nilable(T::Boolean)).returns(T::Boolean) }
         def read_only(val = nil); end
 
-        sig { returns(KubeDSL::DSL::V1::SecretReference) }
-        def secret_ref; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::SecretReference).void)).returns(KubeDSL::DSL::V1::SecretReference) }
+        def secret_ref(&block); end
 
         sig { returns(T::Boolean) }
         def secret_ref_present?; end
@@ -14888,8 +14888,8 @@ module KubeDSL
         sig { params(val: T.nilable(T::Boolean)).returns(T::Boolean) }
         def read_only(val = nil); end
 
-        sig { returns(KubeDSL::DSL::V1::LocalObjectReference) }
-        def secret_ref; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::LocalObjectReference).void)).returns(KubeDSL::DSL::V1::LocalObjectReference) }
+        def secret_ref(&block); end
 
         sig { returns(T::Boolean) }
         def secret_ref_present?; end
@@ -14909,20 +14909,20 @@ module KubeDSL
         sig { returns(Symbol) }
         def kind_sym; end
 
-        sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-        def metadata; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+        def metadata(&block); end
 
         sig { returns(T::Boolean) }
         def metadata_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::ReplicationControllerSpec) }
-        def spec; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ReplicationControllerSpec).void)).returns(KubeDSL::DSL::V1::ReplicationControllerSpec) }
+        def spec(&block); end
 
         sig { returns(T::Boolean) }
         def spec_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::ReplicationControllerStatus) }
-        def status; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ReplicationControllerStatus).void)).returns(KubeDSL::DSL::V1::ReplicationControllerStatus) }
+        def status(&block); end
 
         sig { returns(T::Boolean) }
         def status_present?; end
@@ -14969,8 +14969,8 @@ module KubeDSL
         sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::V1::ReplicationController))).returns(T::Array[KubeDSL::DSL::V1::ReplicationController]) }
         def items(elem_name = nil, &block); end
 
-        sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-        def metadata; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+        def metadata(&block); end
 
         sig { returns(T::Boolean) }
         def metadata_present?; end
@@ -14993,11 +14993,11 @@ module KubeDSL
         sig { params(val: T.nilable(Integer)).returns(Integer) }
         def replicas(val = nil); end
 
-        sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+        sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
         def selector(&block); end
 
-        sig { returns(KubeDSL::DSL::V1::PodTemplateSpec) }
-        def template; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PodTemplateSpec).void)).returns(KubeDSL::DSL::V1::PodTemplateSpec) }
+        def template(&block); end
 
         sig { returns(T::Boolean) }
         def template_present?; end
@@ -15065,20 +15065,20 @@ module KubeDSL
         sig { returns(Symbol) }
         def kind_sym; end
 
-        sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-        def metadata; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+        def metadata(&block); end
 
         sig { returns(T::Boolean) }
         def metadata_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::ResourceQuotaSpec) }
-        def spec; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ResourceQuotaSpec).void)).returns(KubeDSL::DSL::V1::ResourceQuotaSpec) }
+        def spec(&block); end
 
         sig { returns(T::Boolean) }
         def spec_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::ResourceQuotaStatus) }
-        def status; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ResourceQuotaStatus).void)).returns(KubeDSL::DSL::V1::ResourceQuotaStatus) }
+        def status(&block); end
 
         sig { returns(T::Boolean) }
         def status_present?; end
@@ -15098,8 +15098,8 @@ module KubeDSL
         sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::V1::ResourceQuota))).returns(T::Array[KubeDSL::DSL::V1::ResourceQuota]) }
         def items(elem_name = nil, &block); end
 
-        sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-        def metadata; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+        def metadata(&block); end
 
         sig { returns(T::Boolean) }
         def metadata_present?; end
@@ -15116,11 +15116,11 @@ module KubeDSL
         sig { returns(Symbol) }
         def kind_sym; end
 
-        sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+        sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
         def hard(&block); end
 
-        sig { returns(KubeDSL::DSL::V1::ScopeSelector) }
-        def scope_selector; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ScopeSelector).void)).returns(KubeDSL::DSL::V1::ScopeSelector) }
+        def scope_selector(&block); end
 
         sig { returns(T::Boolean) }
         def scope_selector_present?; end
@@ -15140,10 +15140,10 @@ module KubeDSL
         sig { returns(Symbol) }
         def kind_sym; end
 
-        sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+        sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
         def hard(&block); end
 
-        sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+        sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
         def used(&block); end
       end
 
@@ -15158,10 +15158,10 @@ module KubeDSL
         sig { returns(Symbol) }
         def kind_sym; end
 
-        sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+        sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
         def limits(&block); end
 
-        sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+        sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
         def requests(&block); end
       end
 
@@ -15188,8 +15188,8 @@ module KubeDSL
         sig { params(val: T.nilable(T::Boolean)).returns(T::Boolean) }
         def read_only(val = nil); end
 
-        sig { returns(KubeDSL::DSL::V1::SecretReference) }
-        def secret_ref; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::SecretReference).void)).returns(KubeDSL::DSL::V1::SecretReference) }
+        def secret_ref(&block); end
 
         sig { returns(T::Boolean) }
         def secret_ref_present?; end
@@ -15233,8 +15233,8 @@ module KubeDSL
         sig { params(val: T.nilable(T::Boolean)).returns(T::Boolean) }
         def read_only(val = nil); end
 
-        sig { returns(KubeDSL::DSL::V1::LocalObjectReference) }
-        def secret_ref; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::LocalObjectReference).void)).returns(KubeDSL::DSL::V1::LocalObjectReference) }
+        def secret_ref(&block); end
 
         sig { returns(T::Boolean) }
         def secret_ref_present?; end
@@ -15344,19 +15344,19 @@ module KubeDSL
         sig { returns(Symbol) }
         def kind_sym; end
 
-        sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+        sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
         def data(&block); end
 
         sig { params(val: T.nilable(T::Boolean)).returns(T::Boolean) }
         def immutable(val = nil); end
 
-        sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-        def metadata; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+        def metadata(&block); end
 
         sig { returns(T::Boolean) }
         def metadata_present?; end
 
-        sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+        sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
         def string_data(&block); end
 
         sig { params(val: T.nilable(String)).returns(String) }
@@ -15416,8 +15416,8 @@ module KubeDSL
         sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::V1::Secret))).returns(T::Array[KubeDSL::DSL::V1::Secret]) }
         def items(elem_name = nil, &block); end
 
-        sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-        def metadata; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+        def metadata(&block); end
 
         sig { returns(T::Boolean) }
         def metadata_present?; end
@@ -15500,8 +15500,8 @@ module KubeDSL
         sig { params(val: T.nilable(T::Boolean)).returns(T::Boolean) }
         def allow_privilege_escalation(val = nil); end
 
-        sig { returns(KubeDSL::DSL::V1::Capabilities) }
-        def capabilities; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::Capabilities).void)).returns(KubeDSL::DSL::V1::Capabilities) }
+        def capabilities(&block); end
 
         sig { returns(T::Boolean) }
         def capabilities_present?; end
@@ -15524,20 +15524,20 @@ module KubeDSL
         sig { params(val: T.nilable(Integer)).returns(Integer) }
         def run_as_user(val = nil); end
 
-        sig { returns(KubeDSL::DSL::V1::SELinuxOptions) }
-        def se_linux_options; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::SELinuxOptions).void)).returns(KubeDSL::DSL::V1::SELinuxOptions) }
+        def se_linux_options(&block); end
 
         sig { returns(T::Boolean) }
         def se_linux_options_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::SeccompProfile) }
-        def seccomp_profile; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::SeccompProfile).void)).returns(KubeDSL::DSL::V1::SeccompProfile) }
+        def seccomp_profile(&block); end
 
         sig { returns(T::Boolean) }
         def seccomp_profile_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::WindowsSecurityContextOptions) }
-        def windows_options; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::WindowsSecurityContextOptions).void)).returns(KubeDSL::DSL::V1::WindowsSecurityContextOptions) }
+        def windows_options(&block); end
 
         sig { returns(T::Boolean) }
         def windows_options_present?; end
@@ -15554,20 +15554,20 @@ module KubeDSL
         sig { returns(Symbol) }
         def kind_sym; end
 
-        sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-        def metadata; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+        def metadata(&block); end
 
         sig { returns(T::Boolean) }
         def metadata_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::ServiceSpec) }
-        def spec; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ServiceSpec).void)).returns(KubeDSL::DSL::V1::ServiceSpec) }
+        def spec(&block); end
 
         sig { returns(T::Boolean) }
         def spec_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::ServiceStatus) }
-        def status; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ServiceStatus).void)).returns(KubeDSL::DSL::V1::ServiceStatus) }
+        def status(&block); end
 
         sig { returns(T::Boolean) }
         def status_present?; end
@@ -15590,8 +15590,8 @@ module KubeDSL
         sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::V1::LocalObjectReference))).returns(T::Array[KubeDSL::DSL::V1::LocalObjectReference]) }
         def image_pull_secrets(elem_name = nil, &block); end
 
-        sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-        def metadata; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+        def metadata(&block); end
 
         sig { returns(T::Boolean) }
         def metadata_present?; end
@@ -15614,8 +15614,8 @@ module KubeDSL
         sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::V1::ServiceAccount))).returns(T::Array[KubeDSL::DSL::V1::ServiceAccount]) }
         def items(elem_name = nil, &block); end
 
-        sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-        def metadata; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+        def metadata(&block); end
 
         sig { returns(T::Boolean) }
         def metadata_present?; end
@@ -15656,8 +15656,8 @@ module KubeDSL
         sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::V1::Service))).returns(T::Array[KubeDSL::DSL::V1::Service]) }
         def items(elem_name = nil, &block); end
 
-        sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-        def metadata; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+        def metadata(&block); end
 
         sig { returns(T::Boolean) }
         def metadata_present?; end
@@ -15749,14 +15749,14 @@ module KubeDSL
         sig { params(val: T.nilable(T::Boolean)).returns(T::Boolean) }
         def publish_not_ready_addresses(val = nil); end
 
-        sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+        sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
         def selector(&block); end
 
         sig { params(val: T.nilable(String)).returns(String) }
         def session_affinity(val = nil); end
 
-        sig { returns(KubeDSL::DSL::V1::SessionAffinityConfig) }
-        def session_affinity_config; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::SessionAffinityConfig).void)).returns(KubeDSL::DSL::V1::SessionAffinityConfig) }
+        def session_affinity_config(&block); end
 
         sig { returns(T::Boolean) }
         def session_affinity_config_present?; end
@@ -15779,8 +15779,8 @@ module KubeDSL
         sig { params(elem_name: T.nilable(Symbol), block: T.nilable(T.proc.returns(KubeDSL::DSL::Meta::V1::Condition))).returns(T::Array[KubeDSL::DSL::Meta::V1::Condition]) }
         def conditions(elem_name = nil, &block); end
 
-        sig { returns(KubeDSL::DSL::V1::LoadBalancerStatus) }
-        def load_balancer; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::LoadBalancerStatus).void)).returns(KubeDSL::DSL::V1::LoadBalancerStatus) }
+        def load_balancer(&block); end
 
         sig { returns(T::Boolean) }
         def load_balancer_present?; end
@@ -15797,8 +15797,8 @@ module KubeDSL
         sig { returns(Symbol) }
         def kind_sym; end
 
-        sig { returns(KubeDSL::DSL::V1::ClientIPConfig) }
-        def client_ip; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ClientIPConfig).void)).returns(KubeDSL::DSL::V1::ClientIPConfig) }
+        def client_ip(&block); end
 
         sig { returns(T::Boolean) }
         def client_ip_present?; end
@@ -15821,8 +15821,8 @@ module KubeDSL
         sig { params(val: T.nilable(T::Boolean)).returns(T::Boolean) }
         def read_only(val = nil); end
 
-        sig { returns(KubeDSL::DSL::V1::ObjectReference) }
-        def secret_ref; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ObjectReference).void)).returns(KubeDSL::DSL::V1::ObjectReference) }
+        def secret_ref(&block); end
 
         sig { returns(T::Boolean) }
         def secret_ref_present?; end
@@ -15851,8 +15851,8 @@ module KubeDSL
         sig { params(val: T.nilable(T::Boolean)).returns(T::Boolean) }
         def read_only(val = nil); end
 
-        sig { returns(KubeDSL::DSL::V1::LocalObjectReference) }
-        def secret_ref; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::LocalObjectReference).void)).returns(KubeDSL::DSL::V1::LocalObjectReference) }
+        def secret_ref(&block); end
 
         sig { returns(T::Boolean) }
         def secret_ref_present?; end
@@ -15995,8 +15995,8 @@ module KubeDSL
         sig { returns(Symbol) }
         def kind_sym; end
 
-        sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-        def label_selector; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+        def label_selector(&block); end
 
         sig { returns(T::Boolean) }
         def label_selector_present?; end
@@ -16043,110 +16043,110 @@ module KubeDSL
         sig { returns(Symbol) }
         def kind_sym; end
 
-        sig { returns(KubeDSL::DSL::V1::AWSElasticBlockStoreVolumeSource) }
-        def aws_elastic_block_store; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::AWSElasticBlockStoreVolumeSource).void)).returns(KubeDSL::DSL::V1::AWSElasticBlockStoreVolumeSource) }
+        def aws_elastic_block_store(&block); end
 
         sig { returns(T::Boolean) }
         def aws_elastic_block_store_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::AzureDiskVolumeSource) }
-        def azure_disk; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::AzureDiskVolumeSource).void)).returns(KubeDSL::DSL::V1::AzureDiskVolumeSource) }
+        def azure_disk(&block); end
 
         sig { returns(T::Boolean) }
         def azure_disk_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::AzureFileVolumeSource) }
-        def azure_file; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::AzureFileVolumeSource).void)).returns(KubeDSL::DSL::V1::AzureFileVolumeSource) }
+        def azure_file(&block); end
 
         sig { returns(T::Boolean) }
         def azure_file_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::CephFSVolumeSource) }
-        def cephfs; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::CephFSVolumeSource).void)).returns(KubeDSL::DSL::V1::CephFSVolumeSource) }
+        def cephfs(&block); end
 
         sig { returns(T::Boolean) }
         def cephfs_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::CinderVolumeSource) }
-        def cinder; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::CinderVolumeSource).void)).returns(KubeDSL::DSL::V1::CinderVolumeSource) }
+        def cinder(&block); end
 
         sig { returns(T::Boolean) }
         def cinder_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::ConfigMapVolumeSource) }
-        def config_map; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ConfigMapVolumeSource).void)).returns(KubeDSL::DSL::V1::ConfigMapVolumeSource) }
+        def config_map(&block); end
 
         sig { returns(T::Boolean) }
         def config_map_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::CSIVolumeSource) }
-        def csi; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::CSIVolumeSource).void)).returns(KubeDSL::DSL::V1::CSIVolumeSource) }
+        def csi(&block); end
 
         sig { returns(T::Boolean) }
         def csi_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::DownwardAPIVolumeSource) }
-        def downward_api; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::DownwardAPIVolumeSource).void)).returns(KubeDSL::DSL::V1::DownwardAPIVolumeSource) }
+        def downward_api(&block); end
 
         sig { returns(T::Boolean) }
         def downward_api_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::EmptyDirVolumeSource) }
-        def empty_dir; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::EmptyDirVolumeSource).void)).returns(KubeDSL::DSL::V1::EmptyDirVolumeSource) }
+        def empty_dir(&block); end
 
         sig { returns(T::Boolean) }
         def empty_dir_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::EphemeralVolumeSource) }
-        def ephemeral; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::EphemeralVolumeSource).void)).returns(KubeDSL::DSL::V1::EphemeralVolumeSource) }
+        def ephemeral(&block); end
 
         sig { returns(T::Boolean) }
         def ephemeral_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::FCVolumeSource) }
-        def fc; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::FCVolumeSource).void)).returns(KubeDSL::DSL::V1::FCVolumeSource) }
+        def fc(&block); end
 
         sig { returns(T::Boolean) }
         def fc_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::FlexVolumeSource) }
-        def flex_volume; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::FlexVolumeSource).void)).returns(KubeDSL::DSL::V1::FlexVolumeSource) }
+        def flex_volume(&block); end
 
         sig { returns(T::Boolean) }
         def flex_volume_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::FlockerVolumeSource) }
-        def flocker; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::FlockerVolumeSource).void)).returns(KubeDSL::DSL::V1::FlockerVolumeSource) }
+        def flocker(&block); end
 
         sig { returns(T::Boolean) }
         def flocker_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::GCEPersistentDiskVolumeSource) }
-        def gce_persistent_disk; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::GCEPersistentDiskVolumeSource).void)).returns(KubeDSL::DSL::V1::GCEPersistentDiskVolumeSource) }
+        def gce_persistent_disk(&block); end
 
         sig { returns(T::Boolean) }
         def gce_persistent_disk_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::GitRepoVolumeSource) }
-        def git_repo; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::GitRepoVolumeSource).void)).returns(KubeDSL::DSL::V1::GitRepoVolumeSource) }
+        def git_repo(&block); end
 
         sig { returns(T::Boolean) }
         def git_repo_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::GlusterfsVolumeSource) }
-        def glusterfs; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::GlusterfsVolumeSource).void)).returns(KubeDSL::DSL::V1::GlusterfsVolumeSource) }
+        def glusterfs(&block); end
 
         sig { returns(T::Boolean) }
         def glusterfs_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::HostPathVolumeSource) }
-        def host_path; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::HostPathVolumeSource).void)).returns(KubeDSL::DSL::V1::HostPathVolumeSource) }
+        def host_path(&block); end
 
         sig { returns(T::Boolean) }
         def host_path_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::ISCSIVolumeSource) }
-        def iscsi; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ISCSIVolumeSource).void)).returns(KubeDSL::DSL::V1::ISCSIVolumeSource) }
+        def iscsi(&block); end
 
         sig { returns(T::Boolean) }
         def iscsi_present?; end
@@ -16154,68 +16154,68 @@ module KubeDSL
         sig { params(val: T.nilable(String)).returns(String) }
         def name(val = nil); end
 
-        sig { returns(KubeDSL::DSL::V1::NFSVolumeSource) }
-        def nfs; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::NFSVolumeSource).void)).returns(KubeDSL::DSL::V1::NFSVolumeSource) }
+        def nfs(&block); end
 
         sig { returns(T::Boolean) }
         def nfs_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::PersistentVolumeClaimVolumeSource) }
-        def persistent_volume_claim; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PersistentVolumeClaimVolumeSource).void)).returns(KubeDSL::DSL::V1::PersistentVolumeClaimVolumeSource) }
+        def persistent_volume_claim(&block); end
 
         sig { returns(T::Boolean) }
         def persistent_volume_claim_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::PhotonPersistentDiskVolumeSource) }
-        def photon_persistent_disk; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PhotonPersistentDiskVolumeSource).void)).returns(KubeDSL::DSL::V1::PhotonPersistentDiskVolumeSource) }
+        def photon_persistent_disk(&block); end
 
         sig { returns(T::Boolean) }
         def photon_persistent_disk_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::PortworxVolumeSource) }
-        def portworx_volume; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PortworxVolumeSource).void)).returns(KubeDSL::DSL::V1::PortworxVolumeSource) }
+        def portworx_volume(&block); end
 
         sig { returns(T::Boolean) }
         def portworx_volume_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::ProjectedVolumeSource) }
-        def projected; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ProjectedVolumeSource).void)).returns(KubeDSL::DSL::V1::ProjectedVolumeSource) }
+        def projected(&block); end
 
         sig { returns(T::Boolean) }
         def projected_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::QuobyteVolumeSource) }
-        def quobyte; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::QuobyteVolumeSource).void)).returns(KubeDSL::DSL::V1::QuobyteVolumeSource) }
+        def quobyte(&block); end
 
         sig { returns(T::Boolean) }
         def quobyte_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::RBDVolumeSource) }
-        def rbd; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::RBDVolumeSource).void)).returns(KubeDSL::DSL::V1::RBDVolumeSource) }
+        def rbd(&block); end
 
         sig { returns(T::Boolean) }
         def rbd_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::ScaleIOVolumeSource) }
-        def scale_io; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ScaleIOVolumeSource).void)).returns(KubeDSL::DSL::V1::ScaleIOVolumeSource) }
+        def scale_io(&block); end
 
         sig { returns(T::Boolean) }
         def scale_io_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::SecretVolumeSource) }
-        def secret; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::SecretVolumeSource).void)).returns(KubeDSL::DSL::V1::SecretVolumeSource) }
+        def secret(&block); end
 
         sig { returns(T::Boolean) }
         def secret_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::StorageOSVolumeSource) }
-        def storageos; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::StorageOSVolumeSource).void)).returns(KubeDSL::DSL::V1::StorageOSVolumeSource) }
+        def storageos(&block); end
 
         sig { returns(T::Boolean) }
         def storageos_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::VsphereVirtualDiskVolumeSource) }
-        def vsphere_volume; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::VsphereVirtualDiskVolumeSource).void)).returns(KubeDSL::DSL::V1::VsphereVirtualDiskVolumeSource) }
+        def vsphere_volume(&block); end
 
         sig { returns(T::Boolean) }
         def vsphere_volume_present?; end
@@ -16280,8 +16280,8 @@ module KubeDSL
         sig { returns(Symbol) }
         def kind_sym; end
 
-        sig { returns(KubeDSL::DSL::V1::NodeSelector) }
-        def required; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::NodeSelector).void)).returns(KubeDSL::DSL::V1::NodeSelector) }
+        def required(&block); end
 
         sig { returns(T::Boolean) }
         def required_present?; end
@@ -16298,26 +16298,26 @@ module KubeDSL
         sig { returns(Symbol) }
         def kind_sym; end
 
-        sig { returns(KubeDSL::DSL::V1::ConfigMapProjection) }
-        def config_map; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ConfigMapProjection).void)).returns(KubeDSL::DSL::V1::ConfigMapProjection) }
+        def config_map(&block); end
 
         sig { returns(T::Boolean) }
         def config_map_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::DownwardAPIProjection) }
-        def downward_api; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::DownwardAPIProjection).void)).returns(KubeDSL::DSL::V1::DownwardAPIProjection) }
+        def downward_api(&block); end
 
         sig { returns(T::Boolean) }
         def downward_api_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::SecretProjection) }
-        def secret; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::SecretProjection).void)).returns(KubeDSL::DSL::V1::SecretProjection) }
+        def secret(&block); end
 
         sig { returns(T::Boolean) }
         def secret_present?; end
 
-        sig { returns(KubeDSL::DSL::V1::ServiceAccountTokenProjection) }
-        def service_account_token; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ServiceAccountTokenProjection).void)).returns(KubeDSL::DSL::V1::ServiceAccountTokenProjection) }
+        def service_account_token(&block); end
 
         sig { returns(T::Boolean) }
         def service_account_token_present?; end
@@ -16358,8 +16358,8 @@ module KubeDSL
         sig { returns(Symbol) }
         def kind_sym; end
 
-        sig { returns(KubeDSL::DSL::V1::PodAffinityTerm) }
-        def pod_affinity_term; end
+        sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PodAffinityTerm).void)).returns(KubeDSL::DSL::V1::PodAffinityTerm) }
+        def pod_affinity_term(&block); end
 
         sig { returns(T::Boolean) }
         def pod_affinity_term_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/admissionregistration/v1/mutating_webhook.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/admissionregistration/v1/mutating_webhook.rbi
@@ -22,8 +22,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def admission_review_versions(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Admissionregistration::V1::WebhookClientConfig) }
-          def client_config; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Admissionregistration::V1::WebhookClientConfig).void)).returns(KubeDSL::DSL::Admissionregistration::V1::WebhookClientConfig) }
+          def client_config(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def client_config_present?; end
@@ -37,14 +37,14 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def name(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-          def namespace_selector; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+          def namespace_selector(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def namespace_selector_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-          def object_selector; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+          def object_selector(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def object_selector_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/admissionregistration/v1/mutating_webhook_configuration.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/admissionregistration/v1/mutating_webhook_configuration.rbi
@@ -21,8 +21,8 @@ module KubeDSL
 
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/admissionregistration/v1/mutating_webhook_configuration_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/admissionregistration/v1/mutating_webhook_configuration_list.rbi
@@ -29,8 +29,8 @@ module KubeDSL
           def items(elem_name = nil, &block); end
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/admissionregistration/v1/validating_webhook.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/admissionregistration/v1/validating_webhook.rbi
@@ -22,8 +22,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def admission_review_versions(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Admissionregistration::V1::WebhookClientConfig) }
-          def client_config; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Admissionregistration::V1::WebhookClientConfig).void)).returns(KubeDSL::DSL::Admissionregistration::V1::WebhookClientConfig) }
+          def client_config(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def client_config_present?; end
@@ -37,14 +37,14 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def name(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-          def namespace_selector; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+          def namespace_selector(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def namespace_selector_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-          def object_selector; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+          def object_selector(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def object_selector_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/admissionregistration/v1/validating_webhook_configuration.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/admissionregistration/v1/validating_webhook_configuration.rbi
@@ -21,8 +21,8 @@ module KubeDSL
 
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/admissionregistration/v1/validating_webhook_configuration_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/admissionregistration/v1/validating_webhook_configuration_list.rbi
@@ -29,8 +29,8 @@ module KubeDSL
           def items(elem_name = nil, &block); end
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/admissionregistration/v1/webhook_client_config.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/admissionregistration/v1/webhook_client_config.rbi
@@ -22,8 +22,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def ca_bundle(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Admissionregistration::V1::ServiceReference) }
-          def service; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Admissionregistration::V1::ServiceReference).void)).returns(KubeDSL::DSL::Admissionregistration::V1::ServiceReference) }
+          def service(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def service_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/apiextensions/v1/custom_resource_conversion.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/apiextensions/v1/custom_resource_conversion.rbi
@@ -22,8 +22,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def strategy(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Apiextensions::V1::WebhookConversion) }
-          def webhook; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apiextensions::V1::WebhookConversion).void)).returns(KubeDSL::DSL::Apiextensions::V1::WebhookConversion) }
+          def webhook(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def webhook_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/apiextensions/v1/custom_resource_definition.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/apiextensions/v1/custom_resource_definition.rbi
@@ -21,20 +21,20 @@ module KubeDSL
 
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionSpec) }
-          def spec; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionSpec).void)).returns(KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionSpec) }
+          def spec(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def spec_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionStatus) }
-          def status; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionStatus).void)).returns(KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionStatus) }
+          def status(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def status_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/apiextensions/v1/custom_resource_definition_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/apiextensions/v1/custom_resource_definition_list.rbi
@@ -29,8 +29,8 @@ module KubeDSL
           def items(elem_name = nil, &block); end
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/apiextensions/v1/custom_resource_definition_spec.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/apiextensions/v1/custom_resource_definition_spec.rbi
@@ -19,8 +19,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Apiextensions::V1::CustomResourceConversion) }
-          def conversion; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apiextensions::V1::CustomResourceConversion).void)).returns(KubeDSL::DSL::Apiextensions::V1::CustomResourceConversion) }
+          def conversion(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def conversion_present?; end
@@ -28,8 +28,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def group(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionNames) }
-          def names; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionNames).void)).returns(KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionNames) }
+          def names(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def names_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/apiextensions/v1/custom_resource_definition_status.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/apiextensions/v1/custom_resource_definition_status.rbi
@@ -19,8 +19,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionNames) }
-          def accepted_names; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionNames).void)).returns(KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionNames) }
+          def accepted_names(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def accepted_names_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/apiextensions/v1/custom_resource_definition_version.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/apiextensions/v1/custom_resource_definition_version.rbi
@@ -36,8 +36,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def name(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Apiextensions::V1::CustomResourceValidation) }
-          def schema; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apiextensions::V1::CustomResourceValidation).void)).returns(KubeDSL::DSL::Apiextensions::V1::CustomResourceValidation) }
+          def schema(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def schema_present?; end
@@ -48,8 +48,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(T::Boolean)).returns(T::Boolean) }
           def storage(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Apiextensions::V1::CustomResourceSubresources) }
-          def subresources; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apiextensions::V1::CustomResourceSubresources).void)).returns(KubeDSL::DSL::Apiextensions::V1::CustomResourceSubresources) }
+          def subresources(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def subresources_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/apiextensions/v1/custom_resource_subresources.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/apiextensions/v1/custom_resource_subresources.rbi
@@ -19,8 +19,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Apiextensions::V1::CustomResourceSubresourceScale) }
-          def scale; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apiextensions::V1::CustomResourceSubresourceScale).void)).returns(KubeDSL::DSL::Apiextensions::V1::CustomResourceSubresourceScale) }
+          def scale(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def scale_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/apiextensions/v1/custom_resource_validation.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/apiextensions/v1/custom_resource_validation.rbi
@@ -19,8 +19,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Apiextensions::V1::JSONSchemaProps) }
-          def open_apiv3_schema; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apiextensions::V1::JSONSchemaProps).void)).returns(KubeDSL::DSL::Apiextensions::V1::JSONSchemaProps) }
+          def open_apiv3_schema(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def open_apiv3_schema_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/apiextensions/v1/json_schema_props.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/apiextensions/v1/json_schema_props.rbi
@@ -44,10 +44,10 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def default(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
           def definitions(&block); end
 
-          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
           def dependencies(&block); end
 
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
@@ -70,8 +70,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(T::Boolean)).returns(T::Boolean) }
           def exclusive_minimum(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Apiextensions::V1::ExternalDocumentation) }
-          def external_docs; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apiextensions::V1::ExternalDocumentation).void)).returns(KubeDSL::DSL::Apiextensions::V1::ExternalDocumentation) }
+          def external_docs(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def external_docs_present?; end
@@ -112,8 +112,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(Integer)).returns(Integer) }
           def multiple_of(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Apiextensions::V1::JSONSchemaProps) }
-          def not_field; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apiextensions::V1::JSONSchemaProps).void)).returns(KubeDSL::DSL::Apiextensions::V1::JSONSchemaProps) }
+          def not_field(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def not_field_present?; end
@@ -132,10 +132,10 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def pattern(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
           def pattern_properties(&block); end
 
-          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
           def properties(&block); end
 
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }

--- a/sorbet/rbi/kube-dsl/dsl/apiextensions/v1/webhook_client_config.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/apiextensions/v1/webhook_client_config.rbi
@@ -22,8 +22,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def ca_bundle(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Apiextensions::V1::ServiceReference) }
-          def service; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apiextensions::V1::ServiceReference).void)).returns(KubeDSL::DSL::Apiextensions::V1::ServiceReference) }
+          def service(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def service_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/apiextensions/v1/webhook_conversion.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/apiextensions/v1/webhook_conversion.rbi
@@ -19,8 +19,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Apiextensions::V1::WebhookClientConfig) }
-          def client_config; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apiextensions::V1::WebhookClientConfig).void)).returns(KubeDSL::DSL::Apiextensions::V1::WebhookClientConfig) }
+          def client_config(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def client_config_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/apiregistration/v1/api_service.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/apiregistration/v1/api_service.rbi
@@ -21,20 +21,20 @@ module KubeDSL
 
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Apiregistration::V1::APIServiceSpec) }
-          def spec; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apiregistration::V1::APIServiceSpec).void)).returns(KubeDSL::DSL::Apiregistration::V1::APIServiceSpec) }
+          def spec(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def spec_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Apiregistration::V1::APIServiceStatus) }
-          def status; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apiregistration::V1::APIServiceStatus).void)).returns(KubeDSL::DSL::Apiregistration::V1::APIServiceStatus) }
+          def status(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def status_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/apiregistration/v1/api_service_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/apiregistration/v1/api_service_list.rbi
@@ -29,8 +29,8 @@ module KubeDSL
           def items(elem_name = nil, &block); end
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/apiregistration/v1/api_service_spec.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/apiregistration/v1/api_service_spec.rbi
@@ -31,8 +31,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(T::Boolean)).returns(T::Boolean) }
           def insecure_skip_tls_verify(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Apiregistration::V1::ServiceReference) }
-          def service; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apiregistration::V1::ServiceReference).void)).returns(KubeDSL::DSL::Apiregistration::V1::ServiceReference) }
+          def service(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def service_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/apiserverinternal/v1alpha1/storage_version.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/apiserverinternal/v1alpha1/storage_version.rbi
@@ -21,8 +21,8 @@ module KubeDSL
 
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -30,8 +30,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def spec(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Apiserverinternal::V1alpha1::StorageVersionStatus) }
-          def status; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apiserverinternal::V1alpha1::StorageVersionStatus).void)).returns(KubeDSL::DSL::Apiserverinternal::V1alpha1::StorageVersionStatus) }
+          def status(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def status_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/apiserverinternal/v1alpha1/storage_version_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/apiserverinternal/v1alpha1/storage_version_list.rbi
@@ -29,8 +29,8 @@ module KubeDSL
           def items(elem_name = nil, &block); end
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/apps/v1/controller_revision.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/apps/v1/controller_revision.rbi
@@ -24,8 +24,8 @@ module KubeDSL
           def data(val = nil); end
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/apps/v1/controller_revision_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/apps/v1/controller_revision_list.rbi
@@ -29,8 +29,8 @@ module KubeDSL
           def items(elem_name = nil, &block); end
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/apps/v1/daemon_set.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/apps/v1/daemon_set.rbi
@@ -21,20 +21,20 @@ module KubeDSL
 
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Apps::V1::DaemonSetSpec) }
-          def spec; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apps::V1::DaemonSetSpec).void)).returns(KubeDSL::DSL::Apps::V1::DaemonSetSpec) }
+          def spec(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def spec_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Apps::V1::DaemonSetStatus) }
-          def status; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apps::V1::DaemonSetStatus).void)).returns(KubeDSL::DSL::Apps::V1::DaemonSetStatus) }
+          def status(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def status_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/apps/v1/daemon_set_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/apps/v1/daemon_set_list.rbi
@@ -29,8 +29,8 @@ module KubeDSL
           def items(elem_name = nil, &block); end
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/apps/v1/daemon_set_spec.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/apps/v1/daemon_set_spec.rbi
@@ -25,20 +25,20 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(Integer)).returns(Integer) }
           def revision_history_limit(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-          def selector; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+          def selector(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def selector_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::PodTemplateSpec) }
-          def template; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PodTemplateSpec).void)).returns(KubeDSL::DSL::V1::PodTemplateSpec) }
+          def template(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def template_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Apps::V1::DaemonSetUpdateStrategy) }
-          def update_strategy; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apps::V1::DaemonSetUpdateStrategy).void)).returns(KubeDSL::DSL::Apps::V1::DaemonSetUpdateStrategy) }
+          def update_strategy(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def update_strategy_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/apps/v1/daemon_set_update_strategy.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/apps/v1/daemon_set_update_strategy.rbi
@@ -19,8 +19,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Apps::V1::RollingUpdateDaemonSet) }
-          def rolling_update; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apps::V1::RollingUpdateDaemonSet).void)).returns(KubeDSL::DSL::Apps::V1::RollingUpdateDaemonSet) }
+          def rolling_update(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def rolling_update_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/apps/v1/deployment.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/apps/v1/deployment.rbi
@@ -21,20 +21,20 @@ module KubeDSL
 
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Apps::V1::DeploymentSpec) }
-          def spec; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apps::V1::DeploymentSpec).void)).returns(KubeDSL::DSL::Apps::V1::DeploymentSpec) }
+          def spec(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def spec_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Apps::V1::DeploymentStatus) }
-          def status; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apps::V1::DeploymentStatus).void)).returns(KubeDSL::DSL::Apps::V1::DeploymentStatus) }
+          def status(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def status_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/apps/v1/deployment_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/apps/v1/deployment_list.rbi
@@ -29,8 +29,8 @@ module KubeDSL
           def items(elem_name = nil, &block); end
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/apps/v1/deployment_spec.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/apps/v1/deployment_spec.rbi
@@ -34,20 +34,20 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(Integer)).returns(Integer) }
           def revision_history_limit(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-          def selector; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+          def selector(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def selector_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Apps::V1::DeploymentStrategy) }
-          def strategy; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apps::V1::DeploymentStrategy).void)).returns(KubeDSL::DSL::Apps::V1::DeploymentStrategy) }
+          def strategy(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def strategy_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::PodTemplateSpec) }
-          def template; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PodTemplateSpec).void)).returns(KubeDSL::DSL::V1::PodTemplateSpec) }
+          def template(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def template_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/apps/v1/deployment_strategy.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/apps/v1/deployment_strategy.rbi
@@ -19,8 +19,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Apps::V1::RollingUpdateDeployment) }
-          def rolling_update; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apps::V1::RollingUpdateDeployment).void)).returns(KubeDSL::DSL::Apps::V1::RollingUpdateDeployment) }
+          def rolling_update(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def rolling_update_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/apps/v1/replica_set.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/apps/v1/replica_set.rbi
@@ -21,20 +21,20 @@ module KubeDSL
 
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Apps::V1::ReplicaSetSpec) }
-          def spec; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apps::V1::ReplicaSetSpec).void)).returns(KubeDSL::DSL::Apps::V1::ReplicaSetSpec) }
+          def spec(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def spec_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Apps::V1::ReplicaSetStatus) }
-          def status; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apps::V1::ReplicaSetStatus).void)).returns(KubeDSL::DSL::Apps::V1::ReplicaSetStatus) }
+          def status(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def status_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/apps/v1/replica_set_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/apps/v1/replica_set_list.rbi
@@ -29,8 +29,8 @@ module KubeDSL
           def items(elem_name = nil, &block); end
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/apps/v1/replica_set_spec.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/apps/v1/replica_set_spec.rbi
@@ -25,14 +25,14 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(Integer)).returns(Integer) }
           def replicas(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-          def selector; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+          def selector(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def selector_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::PodTemplateSpec) }
-          def template; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PodTemplateSpec).void)).returns(KubeDSL::DSL::V1::PodTemplateSpec) }
+          def template(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def template_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/apps/v1/stateful_set.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/apps/v1/stateful_set.rbi
@@ -21,20 +21,20 @@ module KubeDSL
 
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Apps::V1::StatefulSetSpec) }
-          def spec; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apps::V1::StatefulSetSpec).void)).returns(KubeDSL::DSL::Apps::V1::StatefulSetSpec) }
+          def spec(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def spec_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Apps::V1::StatefulSetStatus) }
-          def status; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apps::V1::StatefulSetStatus).void)).returns(KubeDSL::DSL::Apps::V1::StatefulSetStatus) }
+          def status(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def status_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/apps/v1/stateful_set_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/apps/v1/stateful_set_list.rbi
@@ -29,8 +29,8 @@ module KubeDSL
           def items(elem_name = nil, &block); end
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/apps/v1/stateful_set_spec.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/apps/v1/stateful_set_spec.rbi
@@ -22,8 +22,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(Integer)).returns(Integer) }
           def min_ready_seconds(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Apps::V1::StatefulSetPersistentVolumeClaimRetentionPolicy) }
-          def persistent_volume_claim_retention_policy; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apps::V1::StatefulSetPersistentVolumeClaimRetentionPolicy).void)).returns(KubeDSL::DSL::Apps::V1::StatefulSetPersistentVolumeClaimRetentionPolicy) }
+          def persistent_volume_claim_retention_policy(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def persistent_volume_claim_retention_policy_present?; end
@@ -37,8 +37,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(Integer)).returns(Integer) }
           def revision_history_limit(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-          def selector; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+          def selector(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def selector_present?; end
@@ -46,14 +46,14 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def service_name(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::PodTemplateSpec) }
-          def template; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PodTemplateSpec).void)).returns(KubeDSL::DSL::V1::PodTemplateSpec) }
+          def template(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def template_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Apps::V1::StatefulSetUpdateStrategy) }
-          def update_strategy; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apps::V1::StatefulSetUpdateStrategy).void)).returns(KubeDSL::DSL::Apps::V1::StatefulSetUpdateStrategy) }
+          def update_strategy(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def update_strategy_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/apps/v1/stateful_set_update_strategy.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/apps/v1/stateful_set_update_strategy.rbi
@@ -19,8 +19,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Apps::V1::RollingUpdateStatefulSetStrategy) }
-          def rolling_update; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Apps::V1::RollingUpdateStatefulSetStrategy).void)).returns(KubeDSL::DSL::Apps::V1::RollingUpdateStatefulSetStrategy) }
+          def rolling_update(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def rolling_update_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/authentication/v1/token_request.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/authentication/v1/token_request.rbi
@@ -21,20 +21,20 @@ module KubeDSL
 
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Authentication::V1::TokenRequestSpec) }
-          def spec; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Authentication::V1::TokenRequestSpec).void)).returns(KubeDSL::DSL::Authentication::V1::TokenRequestSpec) }
+          def spec(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def spec_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Authentication::V1::TokenRequestStatus) }
-          def status; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Authentication::V1::TokenRequestStatus).void)).returns(KubeDSL::DSL::Authentication::V1::TokenRequestStatus) }
+          def status(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def status_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/authentication/v1/token_request_spec.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/authentication/v1/token_request_spec.rbi
@@ -22,8 +22,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def audiences(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Authentication::V1::BoundObjectReference) }
-          def bound_object_ref; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Authentication::V1::BoundObjectReference).void)).returns(KubeDSL::DSL::Authentication::V1::BoundObjectReference) }
+          def bound_object_ref(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def bound_object_ref_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/authentication/v1/token_review.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/authentication/v1/token_review.rbi
@@ -21,20 +21,20 @@ module KubeDSL
 
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Authentication::V1::TokenReviewSpec) }
-          def spec; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Authentication::V1::TokenReviewSpec).void)).returns(KubeDSL::DSL::Authentication::V1::TokenReviewSpec) }
+          def spec(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def spec_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Authentication::V1::TokenReviewStatus) }
-          def status; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Authentication::V1::TokenReviewStatus).void)).returns(KubeDSL::DSL::Authentication::V1::TokenReviewStatus) }
+          def status(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def status_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/authentication/v1/token_review_status.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/authentication/v1/token_review_status.rbi
@@ -28,8 +28,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def error(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Authentication::V1::UserInfo) }
-          def user; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Authentication::V1::UserInfo).void)).returns(KubeDSL::DSL::Authentication::V1::UserInfo) }
+          def user(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def user_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/authentication/v1/user_info.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/authentication/v1/user_info.rbi
@@ -19,7 +19,7 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
           def extra(&block); end
 
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }

--- a/sorbet/rbi/kube-dsl/dsl/authorization/v1/local_subject_access_review.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/authorization/v1/local_subject_access_review.rbi
@@ -21,20 +21,20 @@ module KubeDSL
 
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Authorization::V1::SubjectAccessReviewSpec) }
-          def spec; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Authorization::V1::SubjectAccessReviewSpec).void)).returns(KubeDSL::DSL::Authorization::V1::SubjectAccessReviewSpec) }
+          def spec(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def spec_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Authorization::V1::SubjectAccessReviewStatus) }
-          def status; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Authorization::V1::SubjectAccessReviewStatus).void)).returns(KubeDSL::DSL::Authorization::V1::SubjectAccessReviewStatus) }
+          def status(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def status_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/authorization/v1/self_subject_access_review.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/authorization/v1/self_subject_access_review.rbi
@@ -21,20 +21,20 @@ module KubeDSL
 
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Authorization::V1::SelfSubjectAccessReviewSpec) }
-          def spec; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Authorization::V1::SelfSubjectAccessReviewSpec).void)).returns(KubeDSL::DSL::Authorization::V1::SelfSubjectAccessReviewSpec) }
+          def spec(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def spec_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Authorization::V1::SubjectAccessReviewStatus) }
-          def status; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Authorization::V1::SubjectAccessReviewStatus).void)).returns(KubeDSL::DSL::Authorization::V1::SubjectAccessReviewStatus) }
+          def status(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def status_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/authorization/v1/self_subject_access_review_spec.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/authorization/v1/self_subject_access_review_spec.rbi
@@ -19,14 +19,14 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Authorization::V1::NonResourceAttributes) }
-          def non_resource_attributes; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Authorization::V1::NonResourceAttributes).void)).returns(KubeDSL::DSL::Authorization::V1::NonResourceAttributes) }
+          def non_resource_attributes(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def non_resource_attributes_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Authorization::V1::ResourceAttributes) }
-          def resource_attributes; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Authorization::V1::ResourceAttributes).void)).returns(KubeDSL::DSL::Authorization::V1::ResourceAttributes) }
+          def resource_attributes(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def resource_attributes_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/authorization/v1/self_subject_rules_review.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/authorization/v1/self_subject_rules_review.rbi
@@ -21,20 +21,20 @@ module KubeDSL
 
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Authorization::V1::SelfSubjectRulesReviewSpec) }
-          def spec; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Authorization::V1::SelfSubjectRulesReviewSpec).void)).returns(KubeDSL::DSL::Authorization::V1::SelfSubjectRulesReviewSpec) }
+          def spec(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def spec_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Authorization::V1::SubjectRulesReviewStatus) }
-          def status; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Authorization::V1::SubjectRulesReviewStatus).void)).returns(KubeDSL::DSL::Authorization::V1::SubjectRulesReviewStatus) }
+          def status(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def status_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/authorization/v1/subject_access_review.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/authorization/v1/subject_access_review.rbi
@@ -21,20 +21,20 @@ module KubeDSL
 
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Authorization::V1::SubjectAccessReviewSpec) }
-          def spec; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Authorization::V1::SubjectAccessReviewSpec).void)).returns(KubeDSL::DSL::Authorization::V1::SubjectAccessReviewSpec) }
+          def spec(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def spec_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Authorization::V1::SubjectAccessReviewStatus) }
-          def status; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Authorization::V1::SubjectAccessReviewStatus).void)).returns(KubeDSL::DSL::Authorization::V1::SubjectAccessReviewStatus) }
+          def status(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def status_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/authorization/v1/subject_access_review_spec.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/authorization/v1/subject_access_review_spec.rbi
@@ -19,20 +19,20 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
           def extra(&block); end
 
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def groups(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Authorization::V1::NonResourceAttributes) }
-          def non_resource_attributes; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Authorization::V1::NonResourceAttributes).void)).returns(KubeDSL::DSL::Authorization::V1::NonResourceAttributes) }
+          def non_resource_attributes(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def non_resource_attributes_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Authorization::V1::ResourceAttributes) }
-          def resource_attributes; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Authorization::V1::ResourceAttributes).void)).returns(KubeDSL::DSL::Authorization::V1::ResourceAttributes) }
+          def resource_attributes(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def resource_attributes_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/autoscaling/v1/horizontal_pod_autoscaler.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/autoscaling/v1/horizontal_pod_autoscaler.rbi
@@ -21,20 +21,20 @@ module KubeDSL
 
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V1::HorizontalPodAutoscalerSpec) }
-          def spec; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V1::HorizontalPodAutoscalerSpec).void)).returns(KubeDSL::DSL::Autoscaling::V1::HorizontalPodAutoscalerSpec) }
+          def spec(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def spec_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V1::HorizontalPodAutoscalerStatus) }
-          def status; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V1::HorizontalPodAutoscalerStatus).void)).returns(KubeDSL::DSL::Autoscaling::V1::HorizontalPodAutoscalerStatus) }
+          def status(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def status_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/autoscaling/v1/horizontal_pod_autoscaler_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/autoscaling/v1/horizontal_pod_autoscaler_list.rbi
@@ -29,8 +29,8 @@ module KubeDSL
           def items(elem_name = nil, &block); end
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/autoscaling/v1/horizontal_pod_autoscaler_spec.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/autoscaling/v1/horizontal_pod_autoscaler_spec.rbi
@@ -25,8 +25,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(Integer)).returns(Integer) }
           def min_replicas(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V1::CrossVersionObjectReference) }
-          def scale_target_ref; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V1::CrossVersionObjectReference).void)).returns(KubeDSL::DSL::Autoscaling::V1::CrossVersionObjectReference) }
+          def scale_target_ref(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def scale_target_ref_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/autoscaling/v1/scale.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/autoscaling/v1/scale.rbi
@@ -21,20 +21,20 @@ module KubeDSL
 
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V1::ScaleSpec) }
-          def spec; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V1::ScaleSpec).void)).returns(KubeDSL::DSL::Autoscaling::V1::ScaleSpec) }
+          def spec(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def spec_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V1::ScaleStatus) }
-          def status; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V1::ScaleStatus).void)).returns(KubeDSL::DSL::Autoscaling::V1::ScaleStatus) }
+          def status(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def status_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/autoscaling/v2/container_resource_metric_source.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/autoscaling/v2/container_resource_metric_source.rbi
@@ -25,8 +25,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def name(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2::MetricTarget) }
-          def target; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::MetricTarget).void)).returns(KubeDSL::DSL::Autoscaling::V2::MetricTarget) }
+          def target(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def target_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/autoscaling/v2/container_resource_metric_status.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/autoscaling/v2/container_resource_metric_status.rbi
@@ -22,8 +22,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def container(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2::MetricValueStatus) }
-          def current; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::MetricValueStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2::MetricValueStatus) }
+          def current(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def current_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/autoscaling/v2/external_metric_source.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/autoscaling/v2/external_metric_source.rbi
@@ -19,14 +19,14 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2::MetricIdentifier) }
-          def metric; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::MetricIdentifier).void)).returns(KubeDSL::DSL::Autoscaling::V2::MetricIdentifier) }
+          def metric(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metric_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2::MetricTarget) }
-          def target; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::MetricTarget).void)).returns(KubeDSL::DSL::Autoscaling::V2::MetricTarget) }
+          def target(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def target_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/autoscaling/v2/external_metric_status.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/autoscaling/v2/external_metric_status.rbi
@@ -19,14 +19,14 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2::MetricValueStatus) }
-          def current; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::MetricValueStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2::MetricValueStatus) }
+          def current(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def current_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2::MetricIdentifier) }
-          def metric; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::MetricIdentifier).void)).returns(KubeDSL::DSL::Autoscaling::V2::MetricIdentifier) }
+          def metric(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metric_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/autoscaling/v2/horizontal_pod_autoscaler.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/autoscaling/v2/horizontal_pod_autoscaler.rbi
@@ -21,20 +21,20 @@ module KubeDSL
 
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscalerSpec) }
-          def spec; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscalerSpec).void)).returns(KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscalerSpec) }
+          def spec(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def spec_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscalerStatus) }
-          def status; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscalerStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscalerStatus) }
+          def status(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def status_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/autoscaling/v2/horizontal_pod_autoscaler_behavior.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/autoscaling/v2/horizontal_pod_autoscaler_behavior.rbi
@@ -19,14 +19,14 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2::HPAScalingRules) }
-          def scale_down; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::HPAScalingRules).void)).returns(KubeDSL::DSL::Autoscaling::V2::HPAScalingRules) }
+          def scale_down(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def scale_down_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2::HPAScalingRules) }
-          def scale_up; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::HPAScalingRules).void)).returns(KubeDSL::DSL::Autoscaling::V2::HPAScalingRules) }
+          def scale_up(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def scale_up_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/autoscaling/v2/horizontal_pod_autoscaler_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/autoscaling/v2/horizontal_pod_autoscaler_list.rbi
@@ -29,8 +29,8 @@ module KubeDSL
           def items(elem_name = nil, &block); end
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/autoscaling/v2/horizontal_pod_autoscaler_spec.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/autoscaling/v2/horizontal_pod_autoscaler_spec.rbi
@@ -19,8 +19,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscalerBehavior) }
-          def behavior; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscalerBehavior).void)).returns(KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscalerBehavior) }
+          def behavior(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def behavior_present?; end
@@ -39,8 +39,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(Integer)).returns(Integer) }
           def min_replicas(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2::CrossVersionObjectReference) }
-          def scale_target_ref; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::CrossVersionObjectReference).void)).returns(KubeDSL::DSL::Autoscaling::V2::CrossVersionObjectReference) }
+          def scale_target_ref(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def scale_target_ref_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/autoscaling/v2/metric_identifier.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/autoscaling/v2/metric_identifier.rbi
@@ -22,8 +22,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def name(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-          def selector; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+          def selector(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def selector_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/autoscaling/v2/metric_spec.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/autoscaling/v2/metric_spec.rbi
@@ -19,32 +19,32 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2::ContainerResourceMetricSource) }
-          def container_resource; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::ContainerResourceMetricSource).void)).returns(KubeDSL::DSL::Autoscaling::V2::ContainerResourceMetricSource) }
+          def container_resource(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def container_resource_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2::ExternalMetricSource) }
-          def external; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::ExternalMetricSource).void)).returns(KubeDSL::DSL::Autoscaling::V2::ExternalMetricSource) }
+          def external(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def external_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2::ObjectMetricSource) }
-          def object; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::ObjectMetricSource).void)).returns(KubeDSL::DSL::Autoscaling::V2::ObjectMetricSource) }
+          def object(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def object_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2::PodsMetricSource) }
-          def pods; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::PodsMetricSource).void)).returns(KubeDSL::DSL::Autoscaling::V2::PodsMetricSource) }
+          def pods(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def pods_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2::ResourceMetricSource) }
-          def resource; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::ResourceMetricSource).void)).returns(KubeDSL::DSL::Autoscaling::V2::ResourceMetricSource) }
+          def resource(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def resource_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/autoscaling/v2/metric_status.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/autoscaling/v2/metric_status.rbi
@@ -19,32 +19,32 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2::ContainerResourceMetricStatus) }
-          def container_resource; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::ContainerResourceMetricStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2::ContainerResourceMetricStatus) }
+          def container_resource(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def container_resource_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2::ExternalMetricStatus) }
-          def external; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::ExternalMetricStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2::ExternalMetricStatus) }
+          def external(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def external_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2::ObjectMetricStatus) }
-          def object; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::ObjectMetricStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2::ObjectMetricStatus) }
+          def object(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def object_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2::PodsMetricStatus) }
-          def pods; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::PodsMetricStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2::PodsMetricStatus) }
+          def pods(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def pods_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2::ResourceMetricStatus) }
-          def resource; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::ResourceMetricStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2::ResourceMetricStatus) }
+          def resource(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def resource_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/autoscaling/v2/object_metric_source.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/autoscaling/v2/object_metric_source.rbi
@@ -19,20 +19,20 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2::CrossVersionObjectReference) }
-          def described_object; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::CrossVersionObjectReference).void)).returns(KubeDSL::DSL::Autoscaling::V2::CrossVersionObjectReference) }
+          def described_object(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def described_object_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2::MetricIdentifier) }
-          def metric; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::MetricIdentifier).void)).returns(KubeDSL::DSL::Autoscaling::V2::MetricIdentifier) }
+          def metric(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metric_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2::MetricTarget) }
-          def target; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::MetricTarget).void)).returns(KubeDSL::DSL::Autoscaling::V2::MetricTarget) }
+          def target(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def target_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/autoscaling/v2/object_metric_status.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/autoscaling/v2/object_metric_status.rbi
@@ -19,20 +19,20 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2::MetricValueStatus) }
-          def current; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::MetricValueStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2::MetricValueStatus) }
+          def current(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def current_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2::CrossVersionObjectReference) }
-          def described_object; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::CrossVersionObjectReference).void)).returns(KubeDSL::DSL::Autoscaling::V2::CrossVersionObjectReference) }
+          def described_object(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def described_object_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2::MetricIdentifier) }
-          def metric; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::MetricIdentifier).void)).returns(KubeDSL::DSL::Autoscaling::V2::MetricIdentifier) }
+          def metric(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metric_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/autoscaling/v2/pods_metric_source.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/autoscaling/v2/pods_metric_source.rbi
@@ -19,14 +19,14 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2::MetricIdentifier) }
-          def metric; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::MetricIdentifier).void)).returns(KubeDSL::DSL::Autoscaling::V2::MetricIdentifier) }
+          def metric(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metric_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2::MetricTarget) }
-          def target; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::MetricTarget).void)).returns(KubeDSL::DSL::Autoscaling::V2::MetricTarget) }
+          def target(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def target_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/autoscaling/v2/pods_metric_status.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/autoscaling/v2/pods_metric_status.rbi
@@ -19,14 +19,14 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2::MetricValueStatus) }
-          def current; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::MetricValueStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2::MetricValueStatus) }
+          def current(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def current_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2::MetricIdentifier) }
-          def metric; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::MetricIdentifier).void)).returns(KubeDSL::DSL::Autoscaling::V2::MetricIdentifier) }
+          def metric(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metric_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/autoscaling/v2/resource_metric_source.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/autoscaling/v2/resource_metric_source.rbi
@@ -22,8 +22,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def name(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2::MetricTarget) }
-          def target; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::MetricTarget).void)).returns(KubeDSL::DSL::Autoscaling::V2::MetricTarget) }
+          def target(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def target_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/autoscaling/v2/resource_metric_status.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/autoscaling/v2/resource_metric_status.rbi
@@ -19,8 +19,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2::MetricValueStatus) }
-          def current; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2::MetricValueStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2::MetricValueStatus) }
+          def current(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def current_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta1/external_metric_source.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta1/external_metric_source.rbi
@@ -22,8 +22,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def metric_name(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-          def metric_selector; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+          def metric_selector(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metric_selector_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta1/external_metric_status.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta1/external_metric_status.rbi
@@ -28,8 +28,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def metric_name(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-          def metric_selector; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+          def metric_selector(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metric_selector_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta1/horizontal_pod_autoscaler.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta1/horizontal_pod_autoscaler.rbi
@@ -21,20 +21,20 @@ module KubeDSL
 
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2beta1::HorizontalPodAutoscalerSpec) }
-          def spec; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta1::HorizontalPodAutoscalerSpec).void)).returns(KubeDSL::DSL::Autoscaling::V2beta1::HorizontalPodAutoscalerSpec) }
+          def spec(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def spec_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2beta1::HorizontalPodAutoscalerStatus) }
-          def status; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta1::HorizontalPodAutoscalerStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2beta1::HorizontalPodAutoscalerStatus) }
+          def status(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def status_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta1/horizontal_pod_autoscaler_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta1/horizontal_pod_autoscaler_list.rbi
@@ -29,8 +29,8 @@ module KubeDSL
           def items(elem_name = nil, &block); end
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta1/horizontal_pod_autoscaler_spec.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta1/horizontal_pod_autoscaler_spec.rbi
@@ -33,8 +33,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(Integer)).returns(Integer) }
           def min_replicas(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2beta1::CrossVersionObjectReference) }
-          def scale_target_ref; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta1::CrossVersionObjectReference).void)).returns(KubeDSL::DSL::Autoscaling::V2beta1::CrossVersionObjectReference) }
+          def scale_target_ref(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def scale_target_ref_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta1/metric_spec.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta1/metric_spec.rbi
@@ -19,32 +19,32 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2beta1::ContainerResourceMetricSource) }
-          def container_resource; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta1::ContainerResourceMetricSource).void)).returns(KubeDSL::DSL::Autoscaling::V2beta1::ContainerResourceMetricSource) }
+          def container_resource(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def container_resource_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2beta1::ExternalMetricSource) }
-          def external; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta1::ExternalMetricSource).void)).returns(KubeDSL::DSL::Autoscaling::V2beta1::ExternalMetricSource) }
+          def external(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def external_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2beta1::ObjectMetricSource) }
-          def object; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta1::ObjectMetricSource).void)).returns(KubeDSL::DSL::Autoscaling::V2beta1::ObjectMetricSource) }
+          def object(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def object_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2beta1::PodsMetricSource) }
-          def pods; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta1::PodsMetricSource).void)).returns(KubeDSL::DSL::Autoscaling::V2beta1::PodsMetricSource) }
+          def pods(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def pods_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2beta1::ResourceMetricSource) }
-          def resource; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta1::ResourceMetricSource).void)).returns(KubeDSL::DSL::Autoscaling::V2beta1::ResourceMetricSource) }
+          def resource(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def resource_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta1/metric_status.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta1/metric_status.rbi
@@ -19,32 +19,32 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2beta1::ContainerResourceMetricStatus) }
-          def container_resource; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta1::ContainerResourceMetricStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2beta1::ContainerResourceMetricStatus) }
+          def container_resource(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def container_resource_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2beta1::ExternalMetricStatus) }
-          def external; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta1::ExternalMetricStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2beta1::ExternalMetricStatus) }
+          def external(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def external_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2beta1::ObjectMetricStatus) }
-          def object; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta1::ObjectMetricStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2beta1::ObjectMetricStatus) }
+          def object(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def object_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2beta1::PodsMetricStatus) }
-          def pods; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta1::PodsMetricStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2beta1::PodsMetricStatus) }
+          def pods(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def pods_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2beta1::ResourceMetricStatus) }
-          def resource; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta1::ResourceMetricStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2beta1::ResourceMetricStatus) }
+          def resource(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def resource_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta1/object_metric_source.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta1/object_metric_source.rbi
@@ -25,14 +25,14 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def metric_name(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-          def selector; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+          def selector(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def selector_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2beta1::CrossVersionObjectReference) }
-          def target; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta1::CrossVersionObjectReference).void)).returns(KubeDSL::DSL::Autoscaling::V2beta1::CrossVersionObjectReference) }
+          def target(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def target_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta1/object_metric_status.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta1/object_metric_status.rbi
@@ -28,14 +28,14 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def metric_name(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-          def selector; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+          def selector(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def selector_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2beta1::CrossVersionObjectReference) }
-          def target; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta1::CrossVersionObjectReference).void)).returns(KubeDSL::DSL::Autoscaling::V2beta1::CrossVersionObjectReference) }
+          def target(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def target_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta1/pods_metric_source.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta1/pods_metric_source.rbi
@@ -22,8 +22,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def metric_name(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-          def selector; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+          def selector(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def selector_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta1/pods_metric_status.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta1/pods_metric_status.rbi
@@ -25,8 +25,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def metric_name(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-          def selector; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+          def selector(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def selector_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta2/container_resource_metric_source.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta2/container_resource_metric_source.rbi
@@ -25,8 +25,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def name(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricTarget) }
-          def target; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::MetricTarget).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricTarget) }
+          def target(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def target_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta2/container_resource_metric_status.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta2/container_resource_metric_status.rbi
@@ -22,8 +22,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def container(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricValueStatus) }
-          def current; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::MetricValueStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricValueStatus) }
+          def current(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def current_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta2/external_metric_source.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta2/external_metric_source.rbi
@@ -19,14 +19,14 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricIdentifier) }
-          def metric; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::MetricIdentifier).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricIdentifier) }
+          def metric(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metric_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricTarget) }
-          def target; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::MetricTarget).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricTarget) }
+          def target(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def target_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta2/external_metric_status.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta2/external_metric_status.rbi
@@ -19,14 +19,14 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricValueStatus) }
-          def current; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::MetricValueStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricValueStatus) }
+          def current(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def current_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricIdentifier) }
-          def metric; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::MetricIdentifier).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricIdentifier) }
+          def metric(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metric_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta2/horizontal_pod_autoscaler.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta2/horizontal_pod_autoscaler.rbi
@@ -21,20 +21,20 @@ module KubeDSL
 
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::HorizontalPodAutoscalerSpec) }
-          def spec; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::HorizontalPodAutoscalerSpec).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::HorizontalPodAutoscalerSpec) }
+          def spec(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def spec_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::HorizontalPodAutoscalerStatus) }
-          def status; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::HorizontalPodAutoscalerStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::HorizontalPodAutoscalerStatus) }
+          def status(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def status_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta2/horizontal_pod_autoscaler_behavior.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta2/horizontal_pod_autoscaler_behavior.rbi
@@ -19,14 +19,14 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::HPAScalingRules) }
-          def scale_down; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::HPAScalingRules).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::HPAScalingRules) }
+          def scale_down(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def scale_down_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::HPAScalingRules) }
-          def scale_up; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::HPAScalingRules).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::HPAScalingRules) }
+          def scale_up(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def scale_up_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta2/horizontal_pod_autoscaler_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta2/horizontal_pod_autoscaler_list.rbi
@@ -29,8 +29,8 @@ module KubeDSL
           def items(elem_name = nil, &block); end
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta2/horizontal_pod_autoscaler_spec.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta2/horizontal_pod_autoscaler_spec.rbi
@@ -19,8 +19,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::HorizontalPodAutoscalerBehavior) }
-          def behavior; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::HorizontalPodAutoscalerBehavior).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::HorizontalPodAutoscalerBehavior) }
+          def behavior(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def behavior_present?; end
@@ -39,8 +39,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(Integer)).returns(Integer) }
           def min_replicas(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::CrossVersionObjectReference) }
-          def scale_target_ref; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::CrossVersionObjectReference).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::CrossVersionObjectReference) }
+          def scale_target_ref(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def scale_target_ref_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta2/metric_identifier.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta2/metric_identifier.rbi
@@ -22,8 +22,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def name(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-          def selector; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+          def selector(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def selector_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta2/metric_spec.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta2/metric_spec.rbi
@@ -19,32 +19,32 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::ContainerResourceMetricSource) }
-          def container_resource; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::ContainerResourceMetricSource).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::ContainerResourceMetricSource) }
+          def container_resource(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def container_resource_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::ExternalMetricSource) }
-          def external; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::ExternalMetricSource).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::ExternalMetricSource) }
+          def external(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def external_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::ObjectMetricSource) }
-          def object; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::ObjectMetricSource).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::ObjectMetricSource) }
+          def object(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def object_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::PodsMetricSource) }
-          def pods; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::PodsMetricSource).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::PodsMetricSource) }
+          def pods(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def pods_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::ResourceMetricSource) }
-          def resource; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::ResourceMetricSource).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::ResourceMetricSource) }
+          def resource(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def resource_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta2/metric_status.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta2/metric_status.rbi
@@ -19,32 +19,32 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::ContainerResourceMetricStatus) }
-          def container_resource; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::ContainerResourceMetricStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::ContainerResourceMetricStatus) }
+          def container_resource(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def container_resource_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::ExternalMetricStatus) }
-          def external; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::ExternalMetricStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::ExternalMetricStatus) }
+          def external(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def external_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::ObjectMetricStatus) }
-          def object; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::ObjectMetricStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::ObjectMetricStatus) }
+          def object(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def object_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::PodsMetricStatus) }
-          def pods; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::PodsMetricStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::PodsMetricStatus) }
+          def pods(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def pods_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::ResourceMetricStatus) }
-          def resource; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::ResourceMetricStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::ResourceMetricStatus) }
+          def resource(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def resource_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta2/object_metric_source.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta2/object_metric_source.rbi
@@ -19,20 +19,20 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::CrossVersionObjectReference) }
-          def described_object; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::CrossVersionObjectReference).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::CrossVersionObjectReference) }
+          def described_object(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def described_object_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricIdentifier) }
-          def metric; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::MetricIdentifier).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricIdentifier) }
+          def metric(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metric_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricTarget) }
-          def target; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::MetricTarget).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricTarget) }
+          def target(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def target_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta2/object_metric_status.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta2/object_metric_status.rbi
@@ -19,20 +19,20 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricValueStatus) }
-          def current; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::MetricValueStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricValueStatus) }
+          def current(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def current_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::CrossVersionObjectReference) }
-          def described_object; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::CrossVersionObjectReference).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::CrossVersionObjectReference) }
+          def described_object(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def described_object_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricIdentifier) }
-          def metric; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::MetricIdentifier).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricIdentifier) }
+          def metric(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metric_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta2/pods_metric_source.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta2/pods_metric_source.rbi
@@ -19,14 +19,14 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricIdentifier) }
-          def metric; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::MetricIdentifier).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricIdentifier) }
+          def metric(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metric_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricTarget) }
-          def target; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::MetricTarget).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricTarget) }
+          def target(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def target_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta2/pods_metric_status.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta2/pods_metric_status.rbi
@@ -19,14 +19,14 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricValueStatus) }
-          def current; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::MetricValueStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricValueStatus) }
+          def current(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def current_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricIdentifier) }
-          def metric; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::MetricIdentifier).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricIdentifier) }
+          def metric(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metric_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta2/resource_metric_source.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta2/resource_metric_source.rbi
@@ -22,8 +22,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def name(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricTarget) }
-          def target; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::MetricTarget).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricTarget) }
+          def target(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def target_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta2/resource_metric_status.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/autoscaling/v2beta2/resource_metric_status.rbi
@@ -19,8 +19,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricValueStatus) }
-          def current; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Autoscaling::V2beta2::MetricValueStatus).void)).returns(KubeDSL::DSL::Autoscaling::V2beta2::MetricValueStatus) }
+          def current(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def current_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/batch/v1/cron_job.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/batch/v1/cron_job.rbi
@@ -21,20 +21,20 @@ module KubeDSL
 
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Batch::V1::CronJobSpec) }
-          def spec; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Batch::V1::CronJobSpec).void)).returns(KubeDSL::DSL::Batch::V1::CronJobSpec) }
+          def spec(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def spec_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Batch::V1::CronJobStatus) }
-          def status; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Batch::V1::CronJobStatus).void)).returns(KubeDSL::DSL::Batch::V1::CronJobStatus) }
+          def status(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def status_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/batch/v1/cron_job_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/batch/v1/cron_job_list.rbi
@@ -29,8 +29,8 @@ module KubeDSL
           def items(elem_name = nil, &block); end
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/batch/v1/cron_job_spec.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/batch/v1/cron_job_spec.rbi
@@ -25,8 +25,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(Integer)).returns(Integer) }
           def failed_jobs_history_limit(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Batch::V1::JobTemplateSpec) }
-          def job_template; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Batch::V1::JobTemplateSpec).void)).returns(KubeDSL::DSL::Batch::V1::JobTemplateSpec) }
+          def job_template(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def job_template_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/batch/v1/job.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/batch/v1/job.rbi
@@ -21,20 +21,20 @@ module KubeDSL
 
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Batch::V1::JobSpec) }
-          def spec; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Batch::V1::JobSpec).void)).returns(KubeDSL::DSL::Batch::V1::JobSpec) }
+          def spec(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def spec_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Batch::V1::JobStatus) }
-          def status; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Batch::V1::JobStatus).void)).returns(KubeDSL::DSL::Batch::V1::JobStatus) }
+          def status(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def status_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/batch/v1/job_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/batch/v1/job_list.rbi
@@ -29,8 +29,8 @@ module KubeDSL
           def items(elem_name = nil, &block); end
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/batch/v1/job_spec.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/batch/v1/job_spec.rbi
@@ -37,8 +37,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(Integer)).returns(Integer) }
           def parallelism(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-          def selector; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+          def selector(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def selector_present?; end
@@ -46,8 +46,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(T::Boolean)).returns(T::Boolean) }
           def suspend(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::PodTemplateSpec) }
-          def template; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PodTemplateSpec).void)).returns(KubeDSL::DSL::V1::PodTemplateSpec) }
+          def template(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def template_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/batch/v1/job_status.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/batch/v1/job_status.rbi
@@ -48,8 +48,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(Integer)).returns(Integer) }
           def succeeded(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Batch::V1::UncountedTerminatedPods) }
-          def uncounted_terminated_pods; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Batch::V1::UncountedTerminatedPods).void)).returns(KubeDSL::DSL::Batch::V1::UncountedTerminatedPods) }
+          def uncounted_terminated_pods(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def uncounted_terminated_pods_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/batch/v1/job_template_spec.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/batch/v1/job_template_spec.rbi
@@ -19,14 +19,14 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Batch::V1::JobSpec) }
-          def spec; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Batch::V1::JobSpec).void)).returns(KubeDSL::DSL::Batch::V1::JobSpec) }
+          def spec(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def spec_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/batch/v1beta1/cron_job.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/batch/v1beta1/cron_job.rbi
@@ -21,20 +21,20 @@ module KubeDSL
 
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Batch::V1beta1::CronJobSpec) }
-          def spec; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Batch::V1beta1::CronJobSpec).void)).returns(KubeDSL::DSL::Batch::V1beta1::CronJobSpec) }
+          def spec(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def spec_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Batch::V1beta1::CronJobStatus) }
-          def status; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Batch::V1beta1::CronJobStatus).void)).returns(KubeDSL::DSL::Batch::V1beta1::CronJobStatus) }
+          def status(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def status_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/batch/v1beta1/cron_job_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/batch/v1beta1/cron_job_list.rbi
@@ -29,8 +29,8 @@ module KubeDSL
           def items(elem_name = nil, &block); end
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/batch/v1beta1/cron_job_spec.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/batch/v1beta1/cron_job_spec.rbi
@@ -25,8 +25,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(Integer)).returns(Integer) }
           def failed_jobs_history_limit(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Batch::V1beta1::JobTemplateSpec) }
-          def job_template; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Batch::V1beta1::JobTemplateSpec).void)).returns(KubeDSL::DSL::Batch::V1beta1::JobTemplateSpec) }
+          def job_template(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def job_template_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/batch/v1beta1/job_template_spec.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/batch/v1beta1/job_template_spec.rbi
@@ -19,14 +19,14 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Batch::V1::JobSpec) }
-          def spec; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Batch::V1::JobSpec).void)).returns(KubeDSL::DSL::Batch::V1::JobSpec) }
+          def spec(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def spec_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/certificates/v1/certificate_signing_request.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/certificates/v1/certificate_signing_request.rbi
@@ -21,20 +21,20 @@ module KubeDSL
 
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Certificates::V1::CertificateSigningRequestSpec) }
-          def spec; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Certificates::V1::CertificateSigningRequestSpec).void)).returns(KubeDSL::DSL::Certificates::V1::CertificateSigningRequestSpec) }
+          def spec(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def spec_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Certificates::V1::CertificateSigningRequestStatus) }
-          def status; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Certificates::V1::CertificateSigningRequestStatus).void)).returns(KubeDSL::DSL::Certificates::V1::CertificateSigningRequestStatus) }
+          def status(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def status_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/certificates/v1/certificate_signing_request_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/certificates/v1/certificate_signing_request_list.rbi
@@ -29,8 +29,8 @@ module KubeDSL
           def items(elem_name = nil, &block); end
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/certificates/v1/certificate_signing_request_spec.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/certificates/v1/certificate_signing_request_spec.rbi
@@ -22,7 +22,7 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(Integer)).returns(Integer) }
           def expiration_seconds(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
           def extra(&block); end
 
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }

--- a/sorbet/rbi/kube-dsl/dsl/coordination/v1/lease.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/coordination/v1/lease.rbi
@@ -21,14 +21,14 @@ module KubeDSL
 
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Coordination::V1::LeaseSpec) }
-          def spec; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Coordination::V1::LeaseSpec).void)).returns(KubeDSL::DSL::Coordination::V1::LeaseSpec) }
+          def spec(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def spec_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/coordination/v1/lease_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/coordination/v1/lease_list.rbi
@@ -29,8 +29,8 @@ module KubeDSL
           def items(elem_name = nil, &block); end
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/discovery/v1/endpoint.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/discovery/v1/endpoint.rbi
@@ -22,17 +22,17 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def addresses(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Discovery::V1::EndpointConditions) }
-          def conditions; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Discovery::V1::EndpointConditions).void)).returns(KubeDSL::DSL::Discovery::V1::EndpointConditions) }
+          def conditions(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def conditions_present?; end
 
-          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
           def deprecated_topology(&block); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Discovery::V1::EndpointHints) }
-          def hints; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Discovery::V1::EndpointHints).void)).returns(KubeDSL::DSL::Discovery::V1::EndpointHints) }
+          def hints(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def hints_present?; end
@@ -43,8 +43,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def node_name(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::ObjectReference) }
-          def target_ref; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ObjectReference).void)).returns(KubeDSL::DSL::V1::ObjectReference) }
+          def target_ref(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def target_ref_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/discovery/v1/endpoint_slice.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/discovery/v1/endpoint_slice.rbi
@@ -32,8 +32,8 @@ module KubeDSL
           def endpoints(elem_name = nil, &block); end
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/discovery/v1/endpoint_slice_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/discovery/v1/endpoint_slice_list.rbi
@@ -29,8 +29,8 @@ module KubeDSL
           def items(elem_name = nil, &block); end
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/discovery/v1beta1/endpoint.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/discovery/v1beta1/endpoint.rbi
@@ -22,14 +22,14 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def addresses(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Discovery::V1beta1::EndpointConditions) }
-          def conditions; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Discovery::V1beta1::EndpointConditions).void)).returns(KubeDSL::DSL::Discovery::V1beta1::EndpointConditions) }
+          def conditions(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def conditions_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Discovery::V1beta1::EndpointHints) }
-          def hints; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Discovery::V1beta1::EndpointHints).void)).returns(KubeDSL::DSL::Discovery::V1beta1::EndpointHints) }
+          def hints(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def hints_present?; end
@@ -40,13 +40,13 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def node_name(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::ObjectReference) }
-          def target_ref; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ObjectReference).void)).returns(KubeDSL::DSL::V1::ObjectReference) }
+          def target_ref(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def target_ref_present?; end
 
-          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
           def topology(&block); end
         end
       end

--- a/sorbet/rbi/kube-dsl/dsl/discovery/v1beta1/endpoint_slice.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/discovery/v1beta1/endpoint_slice.rbi
@@ -32,8 +32,8 @@ module KubeDSL
           def endpoints(elem_name = nil, &block); end
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/discovery/v1beta1/endpoint_slice_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/discovery/v1beta1/endpoint_slice_list.rbi
@@ -29,8 +29,8 @@ module KubeDSL
           def items(elem_name = nil, &block); end
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/events/v1/event.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/events/v1/event.rbi
@@ -32,8 +32,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def deprecated_last_timestamp(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::EventSource) }
-          def deprecated_source; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::EventSource).void)).returns(KubeDSL::DSL::V1::EventSource) }
+          def deprecated_source(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def deprecated_source_present?; end
@@ -42,8 +42,8 @@ module KubeDSL
           def event_time(val = nil); end
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -54,14 +54,14 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def reason(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::ObjectReference) }
-          def regarding; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ObjectReference).void)).returns(KubeDSL::DSL::V1::ObjectReference) }
+          def regarding(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def regarding_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::ObjectReference) }
-          def related; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ObjectReference).void)).returns(KubeDSL::DSL::V1::ObjectReference) }
+          def related(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def related_present?; end
@@ -72,8 +72,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def reporting_instance(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Events::V1::EventSeries) }
-          def series; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Events::V1::EventSeries).void)).returns(KubeDSL::DSL::Events::V1::EventSeries) }
+          def series(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def series_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/events/v1/event_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/events/v1/event_list.rbi
@@ -29,8 +29,8 @@ module KubeDSL
           def items(elem_name = nil, &block); end
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/events/v1beta1/event.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/events/v1beta1/event.rbi
@@ -32,8 +32,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def deprecated_last_timestamp(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::EventSource) }
-          def deprecated_source; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::EventSource).void)).returns(KubeDSL::DSL::V1::EventSource) }
+          def deprecated_source(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def deprecated_source_present?; end
@@ -42,8 +42,8 @@ module KubeDSL
           def event_time(val = nil); end
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -54,14 +54,14 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def reason(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::ObjectReference) }
-          def regarding; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ObjectReference).void)).returns(KubeDSL::DSL::V1::ObjectReference) }
+          def regarding(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def regarding_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::ObjectReference) }
-          def related; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ObjectReference).void)).returns(KubeDSL::DSL::V1::ObjectReference) }
+          def related(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def related_present?; end
@@ -72,8 +72,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def reporting_instance(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Events::V1beta1::EventSeries) }
-          def series; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Events::V1beta1::EventSeries).void)).returns(KubeDSL::DSL::Events::V1beta1::EventSeries) }
+          def series(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def series_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/events/v1beta1/event_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/events/v1beta1/event_list.rbi
@@ -29,8 +29,8 @@ module KubeDSL
           def items(elem_name = nil, &block); end
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/flowcontrol/v1beta1/flow_schema.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/flowcontrol/v1beta1/flow_schema.rbi
@@ -21,20 +21,20 @@ module KubeDSL
 
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Flowcontrol::V1beta1::FlowSchemaSpec) }
-          def spec; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Flowcontrol::V1beta1::FlowSchemaSpec).void)).returns(KubeDSL::DSL::Flowcontrol::V1beta1::FlowSchemaSpec) }
+          def spec(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def spec_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Flowcontrol::V1beta1::FlowSchemaStatus) }
-          def status; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Flowcontrol::V1beta1::FlowSchemaStatus).void)).returns(KubeDSL::DSL::Flowcontrol::V1beta1::FlowSchemaStatus) }
+          def status(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def status_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/flowcontrol/v1beta1/flow_schema_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/flowcontrol/v1beta1/flow_schema_list.rbi
@@ -29,8 +29,8 @@ module KubeDSL
           def items(elem_name = nil, &block); end
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/flowcontrol/v1beta1/flow_schema_spec.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/flowcontrol/v1beta1/flow_schema_spec.rbi
@@ -19,8 +19,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Flowcontrol::V1beta1::FlowDistinguisherMethod) }
-          def distinguisher_method; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Flowcontrol::V1beta1::FlowDistinguisherMethod).void)).returns(KubeDSL::DSL::Flowcontrol::V1beta1::FlowDistinguisherMethod) }
+          def distinguisher_method(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def distinguisher_method_present?; end
@@ -28,8 +28,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(Integer)).returns(Integer) }
           def matching_precedence(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Flowcontrol::V1beta1::PriorityLevelConfigurationReference) }
-          def priority_level_configuration; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Flowcontrol::V1beta1::PriorityLevelConfigurationReference).void)).returns(KubeDSL::DSL::Flowcontrol::V1beta1::PriorityLevelConfigurationReference) }
+          def priority_level_configuration(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def priority_level_configuration_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/flowcontrol/v1beta1/limit_response.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/flowcontrol/v1beta1/limit_response.rbi
@@ -19,8 +19,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Flowcontrol::V1beta1::QueuingConfiguration) }
-          def queuing; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Flowcontrol::V1beta1::QueuingConfiguration).void)).returns(KubeDSL::DSL::Flowcontrol::V1beta1::QueuingConfiguration) }
+          def queuing(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def queuing_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/flowcontrol/v1beta1/limited_priority_level_configuration.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/flowcontrol/v1beta1/limited_priority_level_configuration.rbi
@@ -22,8 +22,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(Integer)).returns(Integer) }
           def assured_concurrency_shares(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Flowcontrol::V1beta1::LimitResponse) }
-          def limit_response; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Flowcontrol::V1beta1::LimitResponse).void)).returns(KubeDSL::DSL::Flowcontrol::V1beta1::LimitResponse) }
+          def limit_response(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def limit_response_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/flowcontrol/v1beta1/priority_level_configuration.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/flowcontrol/v1beta1/priority_level_configuration.rbi
@@ -21,20 +21,20 @@ module KubeDSL
 
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Flowcontrol::V1beta1::PriorityLevelConfigurationSpec) }
-          def spec; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Flowcontrol::V1beta1::PriorityLevelConfigurationSpec).void)).returns(KubeDSL::DSL::Flowcontrol::V1beta1::PriorityLevelConfigurationSpec) }
+          def spec(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def spec_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Flowcontrol::V1beta1::PriorityLevelConfigurationStatus) }
-          def status; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Flowcontrol::V1beta1::PriorityLevelConfigurationStatus).void)).returns(KubeDSL::DSL::Flowcontrol::V1beta1::PriorityLevelConfigurationStatus) }
+          def status(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def status_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/flowcontrol/v1beta1/priority_level_configuration_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/flowcontrol/v1beta1/priority_level_configuration_list.rbi
@@ -29,8 +29,8 @@ module KubeDSL
           def items(elem_name = nil, &block); end
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/flowcontrol/v1beta1/priority_level_configuration_spec.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/flowcontrol/v1beta1/priority_level_configuration_spec.rbi
@@ -19,8 +19,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Flowcontrol::V1beta1::LimitedPriorityLevelConfiguration) }
-          def limited; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Flowcontrol::V1beta1::LimitedPriorityLevelConfiguration).void)).returns(KubeDSL::DSL::Flowcontrol::V1beta1::LimitedPriorityLevelConfiguration) }
+          def limited(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def limited_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/flowcontrol/v1beta1/subject.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/flowcontrol/v1beta1/subject.rbi
@@ -19,8 +19,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Flowcontrol::V1beta1::GroupSubject) }
-          def group; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Flowcontrol::V1beta1::GroupSubject).void)).returns(KubeDSL::DSL::Flowcontrol::V1beta1::GroupSubject) }
+          def group(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def group_present?; end
@@ -28,14 +28,14 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def kind(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Flowcontrol::V1beta1::ServiceAccountSubject) }
-          def service_account; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Flowcontrol::V1beta1::ServiceAccountSubject).void)).returns(KubeDSL::DSL::Flowcontrol::V1beta1::ServiceAccountSubject) }
+          def service_account(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def service_account_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Flowcontrol::V1beta1::UserSubject) }
-          def user; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Flowcontrol::V1beta1::UserSubject).void)).returns(KubeDSL::DSL::Flowcontrol::V1beta1::UserSubject) }
+          def user(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def user_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/flowcontrol/v1beta2/flow_schema.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/flowcontrol/v1beta2/flow_schema.rbi
@@ -21,20 +21,20 @@ module KubeDSL
 
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Flowcontrol::V1beta2::FlowSchemaSpec) }
-          def spec; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Flowcontrol::V1beta2::FlowSchemaSpec).void)).returns(KubeDSL::DSL::Flowcontrol::V1beta2::FlowSchemaSpec) }
+          def spec(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def spec_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Flowcontrol::V1beta2::FlowSchemaStatus) }
-          def status; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Flowcontrol::V1beta2::FlowSchemaStatus).void)).returns(KubeDSL::DSL::Flowcontrol::V1beta2::FlowSchemaStatus) }
+          def status(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def status_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/flowcontrol/v1beta2/flow_schema_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/flowcontrol/v1beta2/flow_schema_list.rbi
@@ -29,8 +29,8 @@ module KubeDSL
           def items(elem_name = nil, &block); end
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/flowcontrol/v1beta2/flow_schema_spec.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/flowcontrol/v1beta2/flow_schema_spec.rbi
@@ -19,8 +19,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Flowcontrol::V1beta2::FlowDistinguisherMethod) }
-          def distinguisher_method; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Flowcontrol::V1beta2::FlowDistinguisherMethod).void)).returns(KubeDSL::DSL::Flowcontrol::V1beta2::FlowDistinguisherMethod) }
+          def distinguisher_method(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def distinguisher_method_present?; end
@@ -28,8 +28,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(Integer)).returns(Integer) }
           def matching_precedence(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Flowcontrol::V1beta2::PriorityLevelConfigurationReference) }
-          def priority_level_configuration; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Flowcontrol::V1beta2::PriorityLevelConfigurationReference).void)).returns(KubeDSL::DSL::Flowcontrol::V1beta2::PriorityLevelConfigurationReference) }
+          def priority_level_configuration(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def priority_level_configuration_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/flowcontrol/v1beta2/limit_response.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/flowcontrol/v1beta2/limit_response.rbi
@@ -19,8 +19,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Flowcontrol::V1beta2::QueuingConfiguration) }
-          def queuing; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Flowcontrol::V1beta2::QueuingConfiguration).void)).returns(KubeDSL::DSL::Flowcontrol::V1beta2::QueuingConfiguration) }
+          def queuing(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def queuing_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/flowcontrol/v1beta2/limited_priority_level_configuration.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/flowcontrol/v1beta2/limited_priority_level_configuration.rbi
@@ -22,8 +22,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(Integer)).returns(Integer) }
           def assured_concurrency_shares(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Flowcontrol::V1beta2::LimitResponse) }
-          def limit_response; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Flowcontrol::V1beta2::LimitResponse).void)).returns(KubeDSL::DSL::Flowcontrol::V1beta2::LimitResponse) }
+          def limit_response(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def limit_response_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/flowcontrol/v1beta2/priority_level_configuration.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/flowcontrol/v1beta2/priority_level_configuration.rbi
@@ -21,20 +21,20 @@ module KubeDSL
 
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Flowcontrol::V1beta2::PriorityLevelConfigurationSpec) }
-          def spec; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Flowcontrol::V1beta2::PriorityLevelConfigurationSpec).void)).returns(KubeDSL::DSL::Flowcontrol::V1beta2::PriorityLevelConfigurationSpec) }
+          def spec(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def spec_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Flowcontrol::V1beta2::PriorityLevelConfigurationStatus) }
-          def status; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Flowcontrol::V1beta2::PriorityLevelConfigurationStatus).void)).returns(KubeDSL::DSL::Flowcontrol::V1beta2::PriorityLevelConfigurationStatus) }
+          def status(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def status_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/flowcontrol/v1beta2/priority_level_configuration_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/flowcontrol/v1beta2/priority_level_configuration_list.rbi
@@ -29,8 +29,8 @@ module KubeDSL
           def items(elem_name = nil, &block); end
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/flowcontrol/v1beta2/priority_level_configuration_spec.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/flowcontrol/v1beta2/priority_level_configuration_spec.rbi
@@ -19,8 +19,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Flowcontrol::V1beta2::LimitedPriorityLevelConfiguration) }
-          def limited; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Flowcontrol::V1beta2::LimitedPriorityLevelConfiguration).void)).returns(KubeDSL::DSL::Flowcontrol::V1beta2::LimitedPriorityLevelConfiguration) }
+          def limited(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def limited_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/flowcontrol/v1beta2/subject.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/flowcontrol/v1beta2/subject.rbi
@@ -19,8 +19,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Flowcontrol::V1beta2::GroupSubject) }
-          def group; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Flowcontrol::V1beta2::GroupSubject).void)).returns(KubeDSL::DSL::Flowcontrol::V1beta2::GroupSubject) }
+          def group(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def group_present?; end
@@ -28,14 +28,14 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def kind(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Flowcontrol::V1beta2::ServiceAccountSubject) }
-          def service_account; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Flowcontrol::V1beta2::ServiceAccountSubject).void)).returns(KubeDSL::DSL::Flowcontrol::V1beta2::ServiceAccountSubject) }
+          def service_account(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def service_account_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Flowcontrol::V1beta2::UserSubject) }
-          def user; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Flowcontrol::V1beta2::UserSubject).void)).returns(KubeDSL::DSL::Flowcontrol::V1beta2::UserSubject) }
+          def user(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def user_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/meta/v1/api_group.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/meta/v1/api_group.rbi
@@ -24,8 +24,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def name(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::GroupVersionForDiscovery) }
-          def preferred_version; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::GroupVersionForDiscovery).void)).returns(KubeDSL::DSL::Meta::V1::GroupVersionForDiscovery) }
+          def preferred_version(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def preferred_version_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/meta/v1/delete_options.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/meta/v1/delete_options.rbi
@@ -32,8 +32,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(T::Boolean)).returns(T::Boolean) }
           def orphan_dependents(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::Preconditions) }
-          def preconditions; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::Preconditions).void)).returns(KubeDSL::DSL::Meta::V1::Preconditions) }
+          def preconditions(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def preconditions_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/meta/v1/label_selector.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/meta/v1/label_selector.rbi
@@ -27,7 +27,7 @@ module KubeDSL
           }
           def match_expressions(elem_name = nil, &block); end
 
-          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
           def match_labels(&block); end
         end
       end

--- a/sorbet/rbi/kube-dsl/dsl/meta/v1/object_meta.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/meta/v1/object_meta.rbi
@@ -19,7 +19,7 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
           def annotations(&block); end
 
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
@@ -43,7 +43,7 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(Integer)).returns(Integer) }
           def generation(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
           def labels(&block); end
 
           T::Sig::WithoutRuntime.sig {

--- a/sorbet/rbi/kube-dsl/dsl/meta/v1/status.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/meta/v1/status.rbi
@@ -23,8 +23,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(Integer)).returns(Integer) }
           def code(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::StatusDetails) }
-          def details; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::StatusDetails).void)).returns(KubeDSL::DSL::Meta::V1::StatusDetails) }
+          def details(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def details_present?; end
@@ -33,8 +33,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def message(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/networking/v1/http_ingress_path.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/networking/v1/http_ingress_path.rbi
@@ -19,8 +19,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Networking::V1::IngressBackend) }
-          def backend; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Networking::V1::IngressBackend).void)).returns(KubeDSL::DSL::Networking::V1::IngressBackend) }
+          def backend(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def backend_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/networking/v1/ingress.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/networking/v1/ingress.rbi
@@ -21,20 +21,20 @@ module KubeDSL
 
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Networking::V1::IngressSpec) }
-          def spec; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Networking::V1::IngressSpec).void)).returns(KubeDSL::DSL::Networking::V1::IngressSpec) }
+          def spec(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def spec_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Networking::V1::IngressStatus) }
-          def status; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Networking::V1::IngressStatus).void)).returns(KubeDSL::DSL::Networking::V1::IngressStatus) }
+          def status(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def status_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/networking/v1/ingress_backend.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/networking/v1/ingress_backend.rbi
@@ -19,14 +19,14 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::TypedLocalObjectReference) }
-          def resource; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::TypedLocalObjectReference).void)).returns(KubeDSL::DSL::V1::TypedLocalObjectReference) }
+          def resource(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def resource_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Networking::V1::IngressServiceBackend) }
-          def service; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Networking::V1::IngressServiceBackend).void)).returns(KubeDSL::DSL::Networking::V1::IngressServiceBackend) }
+          def service(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def service_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/networking/v1/ingress_class.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/networking/v1/ingress_class.rbi
@@ -21,14 +21,14 @@ module KubeDSL
 
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Networking::V1::IngressClassSpec) }
-          def spec; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Networking::V1::IngressClassSpec).void)).returns(KubeDSL::DSL::Networking::V1::IngressClassSpec) }
+          def spec(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def spec_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/networking/v1/ingress_class_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/networking/v1/ingress_class_list.rbi
@@ -29,8 +29,8 @@ module KubeDSL
           def items(elem_name = nil, &block); end
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/networking/v1/ingress_class_spec.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/networking/v1/ingress_class_spec.rbi
@@ -22,8 +22,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def controller(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Networking::V1::IngressClassParametersReference) }
-          def parameters; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Networking::V1::IngressClassParametersReference).void)).returns(KubeDSL::DSL::Networking::V1::IngressClassParametersReference) }
+          def parameters(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def parameters_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/networking/v1/ingress_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/networking/v1/ingress_list.rbi
@@ -29,8 +29,8 @@ module KubeDSL
           def items(elem_name = nil, &block); end
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/networking/v1/ingress_rule.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/networking/v1/ingress_rule.rbi
@@ -22,8 +22,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def host(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Networking::V1::HTTPIngressRuleValue) }
-          def http; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Networking::V1::HTTPIngressRuleValue).void)).returns(KubeDSL::DSL::Networking::V1::HTTPIngressRuleValue) }
+          def http(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def http_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/networking/v1/ingress_service_backend.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/networking/v1/ingress_service_backend.rbi
@@ -22,8 +22,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def name(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Networking::V1::ServiceBackendPort) }
-          def port; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Networking::V1::ServiceBackendPort).void)).returns(KubeDSL::DSL::Networking::V1::ServiceBackendPort) }
+          def port(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def port_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/networking/v1/ingress_spec.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/networking/v1/ingress_spec.rbi
@@ -19,8 +19,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Networking::V1::IngressBackend) }
-          def default_backend; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Networking::V1::IngressBackend).void)).returns(KubeDSL::DSL::Networking::V1::IngressBackend) }
+          def default_backend(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def default_backend_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/networking/v1/ingress_status.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/networking/v1/ingress_status.rbi
@@ -19,8 +19,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::LoadBalancerStatus) }
-          def load_balancer; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::LoadBalancerStatus).void)).returns(KubeDSL::DSL::V1::LoadBalancerStatus) }
+          def load_balancer(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def load_balancer_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/networking/v1/network_policy.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/networking/v1/network_policy.rbi
@@ -21,14 +21,14 @@ module KubeDSL
 
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Networking::V1::NetworkPolicySpec) }
-          def spec; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Networking::V1::NetworkPolicySpec).void)).returns(KubeDSL::DSL::Networking::V1::NetworkPolicySpec) }
+          def spec(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def spec_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/networking/v1/network_policy_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/networking/v1/network_policy_list.rbi
@@ -29,8 +29,8 @@ module KubeDSL
           def items(elem_name = nil, &block); end
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/networking/v1/network_policy_peer.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/networking/v1/network_policy_peer.rbi
@@ -19,20 +19,20 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Networking::V1::IPBlock) }
-          def ip_block; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Networking::V1::IPBlock).void)).returns(KubeDSL::DSL::Networking::V1::IPBlock) }
+          def ip_block(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def ip_block_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-          def namespace_selector; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+          def namespace_selector(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def namespace_selector_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-          def pod_selector; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+          def pod_selector(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def pod_selector_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/networking/v1/network_policy_spec.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/networking/v1/network_policy_spec.rbi
@@ -35,8 +35,8 @@ module KubeDSL
           }
           def ingresses(elem_name = nil, &block); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-          def pod_selector; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+          def pod_selector(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def pod_selector_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/node/v1/overhead.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/node/v1/overhead.rbi
@@ -21,20 +21,20 @@ module KubeDSL
 
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::NodeSpec) }
-          def spec; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::NodeSpec).void)).returns(KubeDSL::DSL::V1::NodeSpec) }
+          def spec(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def spec_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::NodeStatus) }
-          def status; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::NodeStatus).void)).returns(KubeDSL::DSL::V1::NodeStatus) }
+          def status(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def status_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/node/v1/runtime_class.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/node/v1/runtime_class.rbi
@@ -21,20 +21,20 @@ module KubeDSL
 
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::NodeSpec) }
-          def spec; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::NodeSpec).void)).returns(KubeDSL::DSL::V1::NodeSpec) }
+          def spec(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def spec_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::NodeStatus) }
-          def status; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::NodeStatus).void)).returns(KubeDSL::DSL::V1::NodeStatus) }
+          def status(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def status_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/node/v1/runtime_class_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/node/v1/runtime_class_list.rbi
@@ -21,20 +21,20 @@ module KubeDSL
 
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::NodeSpec) }
-          def spec; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::NodeSpec).void)).returns(KubeDSL::DSL::V1::NodeSpec) }
+          def spec(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def spec_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::NodeStatus) }
-          def status; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::NodeStatus).void)).returns(KubeDSL::DSL::V1::NodeStatus) }
+          def status(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def status_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/node/v1/scheduling.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/node/v1/scheduling.rbi
@@ -21,20 +21,20 @@ module KubeDSL
 
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::NodeSpec) }
-          def spec; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::NodeSpec).void)).returns(KubeDSL::DSL::V1::NodeSpec) }
+          def spec(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def spec_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::NodeStatus) }
-          def status; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::NodeStatus).void)).returns(KubeDSL::DSL::V1::NodeStatus) }
+          def status(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def status_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/node/v1alpha1/overhead.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/node/v1alpha1/overhead.rbi
@@ -19,7 +19,7 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
           def pod_fixed(&block); end
         end
       end

--- a/sorbet/rbi/kube-dsl/dsl/node/v1alpha1/runtime_class.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/node/v1alpha1/runtime_class.rbi
@@ -21,14 +21,14 @@ module KubeDSL
 
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Node::V1alpha1::RuntimeClassSpec) }
-          def spec; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Node::V1alpha1::RuntimeClassSpec).void)).returns(KubeDSL::DSL::Node::V1alpha1::RuntimeClassSpec) }
+          def spec(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def spec_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/node/v1alpha1/runtime_class_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/node/v1alpha1/runtime_class_list.rbi
@@ -29,8 +29,8 @@ module KubeDSL
           def items(elem_name = nil, &block); end
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/node/v1alpha1/runtime_class_spec.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/node/v1alpha1/runtime_class_spec.rbi
@@ -19,8 +19,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Node::V1alpha1::Overhead) }
-          def overhead; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Node::V1alpha1::Overhead).void)).returns(KubeDSL::DSL::Node::V1alpha1::Overhead) }
+          def overhead(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def overhead_present?; end
@@ -28,8 +28,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def runtime_handler(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Node::V1alpha1::Scheduling) }
-          def scheduling; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Node::V1alpha1::Scheduling).void)).returns(KubeDSL::DSL::Node::V1alpha1::Scheduling) }
+          def scheduling(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def scheduling_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/node/v1alpha1/scheduling.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/node/v1alpha1/scheduling.rbi
@@ -19,7 +19,7 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
           def node_selector(&block); end
 
           T::Sig::WithoutRuntime.sig {

--- a/sorbet/rbi/kube-dsl/dsl/node/v1beta1/overhead.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/node/v1beta1/overhead.rbi
@@ -19,7 +19,7 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
           def pod_fixed(&block); end
         end
       end

--- a/sorbet/rbi/kube-dsl/dsl/node/v1beta1/runtime_class.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/node/v1beta1/runtime_class.rbi
@@ -24,20 +24,20 @@ module KubeDSL
           def handler(val = nil); end
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Node::V1beta1::Overhead) }
-          def overhead; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Node::V1beta1::Overhead).void)).returns(KubeDSL::DSL::Node::V1beta1::Overhead) }
+          def overhead(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def overhead_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Node::V1beta1::Scheduling) }
-          def scheduling; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Node::V1beta1::Scheduling).void)).returns(KubeDSL::DSL::Node::V1beta1::Scheduling) }
+          def scheduling(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def scheduling_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/node/v1beta1/runtime_class_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/node/v1beta1/runtime_class_list.rbi
@@ -29,8 +29,8 @@ module KubeDSL
           def items(elem_name = nil, &block); end
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/node/v1beta1/scheduling.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/node/v1beta1/scheduling.rbi
@@ -19,7 +19,7 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
           def node_selector(&block); end
 
           T::Sig::WithoutRuntime.sig {

--- a/sorbet/rbi/kube-dsl/dsl/policy/v1/eviction.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/policy/v1/eviction.rbi
@@ -20,15 +20,15 @@ module KubeDSL
           def kind_sym; end
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::DeleteOptions) }
-          def delete_options; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::DeleteOptions).void)).returns(KubeDSL::DSL::Meta::V1::DeleteOptions) }
+          def delete_options(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def delete_options_present?; end
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/policy/v1/pod_disruption_budget.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/policy/v1/pod_disruption_budget.rbi
@@ -21,20 +21,20 @@ module KubeDSL
 
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Policy::V1::PodDisruptionBudgetSpec) }
-          def spec; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Policy::V1::PodDisruptionBudgetSpec).void)).returns(KubeDSL::DSL::Policy::V1::PodDisruptionBudgetSpec) }
+          def spec(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def spec_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Policy::V1::PodDisruptionBudgetStatus) }
-          def status; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Policy::V1::PodDisruptionBudgetStatus).void)).returns(KubeDSL::DSL::Policy::V1::PodDisruptionBudgetStatus) }
+          def status(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def status_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/policy/v1/pod_disruption_budget_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/policy/v1/pod_disruption_budget_list.rbi
@@ -29,8 +29,8 @@ module KubeDSL
           def items(elem_name = nil, &block); end
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/policy/v1/pod_disruption_budget_spec.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/policy/v1/pod_disruption_budget_spec.rbi
@@ -25,8 +25,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def min_available(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-          def selector; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+          def selector(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def selector_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/policy/v1/pod_disruption_budget_status.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/policy/v1/pod_disruption_budget_status.rbi
@@ -33,7 +33,7 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(Integer)).returns(Integer) }
           def desired_healthy(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
           def disrupted_pods(&block); end
 
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(Integer)).returns(Integer) }

--- a/sorbet/rbi/kube-dsl/dsl/policy/v1beta1/pod_disruption_budget.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/policy/v1beta1/pod_disruption_budget.rbi
@@ -21,20 +21,20 @@ module KubeDSL
 
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Policy::V1beta1::PodDisruptionBudgetSpec) }
-          def spec; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Policy::V1beta1::PodDisruptionBudgetSpec).void)).returns(KubeDSL::DSL::Policy::V1beta1::PodDisruptionBudgetSpec) }
+          def spec(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def spec_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Policy::V1beta1::PodDisruptionBudgetStatus) }
-          def status; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Policy::V1beta1::PodDisruptionBudgetStatus).void)).returns(KubeDSL::DSL::Policy::V1beta1::PodDisruptionBudgetStatus) }
+          def status(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def status_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/policy/v1beta1/pod_disruption_budget_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/policy/v1beta1/pod_disruption_budget_list.rbi
@@ -29,8 +29,8 @@ module KubeDSL
           def items(elem_name = nil, &block); end
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/policy/v1beta1/pod_disruption_budget_spec.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/policy/v1beta1/pod_disruption_budget_spec.rbi
@@ -25,8 +25,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def min_available(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-          def selector; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+          def selector(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def selector_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/policy/v1beta1/pod_disruption_budget_status.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/policy/v1beta1/pod_disruption_budget_status.rbi
@@ -33,7 +33,7 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(Integer)).returns(Integer) }
           def desired_healthy(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
           def disrupted_pods(&block); end
 
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(Integer)).returns(Integer) }

--- a/sorbet/rbi/kube-dsl/dsl/policy/v1beta1/pod_security_policy.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/policy/v1beta1/pod_security_policy.rbi
@@ -21,14 +21,14 @@ module KubeDSL
 
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Policy::V1beta1::PodSecurityPolicySpec) }
-          def spec; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Policy::V1beta1::PodSecurityPolicySpec).void)).returns(KubeDSL::DSL::Policy::V1beta1::PodSecurityPolicySpec) }
+          def spec(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def spec_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/policy/v1beta1/pod_security_policy_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/policy/v1beta1/pod_security_policy_list.rbi
@@ -29,8 +29,8 @@ module KubeDSL
           def items(elem_name = nil, &block); end
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/policy/v1beta1/pod_security_policy_spec.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/policy/v1beta1/pod_security_policy_spec.rbi
@@ -64,8 +64,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def forbidden_sysctls(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Policy::V1beta1::FSGroupStrategyOptions) }
-          def fs_group; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Policy::V1beta1::FSGroupStrategyOptions).void)).returns(KubeDSL::DSL::Policy::V1beta1::FSGroupStrategyOptions) }
+          def fs_group(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def fs_group_present?; end
@@ -96,32 +96,32 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def required_drop_capabilities(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Policy::V1beta1::RunAsGroupStrategyOptions) }
-          def run_as_group; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Policy::V1beta1::RunAsGroupStrategyOptions).void)).returns(KubeDSL::DSL::Policy::V1beta1::RunAsGroupStrategyOptions) }
+          def run_as_group(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def run_as_group_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Policy::V1beta1::RunAsUserStrategyOptions) }
-          def run_as_user; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Policy::V1beta1::RunAsUserStrategyOptions).void)).returns(KubeDSL::DSL::Policy::V1beta1::RunAsUserStrategyOptions) }
+          def run_as_user(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def run_as_user_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Policy::V1beta1::RuntimeClassStrategyOptions) }
-          def runtime_class; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Policy::V1beta1::RuntimeClassStrategyOptions).void)).returns(KubeDSL::DSL::Policy::V1beta1::RuntimeClassStrategyOptions) }
+          def runtime_class(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def runtime_class_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Policy::V1beta1::SELinuxStrategyOptions) }
-          def se_linux; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Policy::V1beta1::SELinuxStrategyOptions).void)).returns(KubeDSL::DSL::Policy::V1beta1::SELinuxStrategyOptions) }
+          def se_linux(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def se_linux_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Policy::V1beta1::SupplementalGroupsStrategyOptions) }
-          def supplemental_groups; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Policy::V1beta1::SupplementalGroupsStrategyOptions).void)).returns(KubeDSL::DSL::Policy::V1beta1::SupplementalGroupsStrategyOptions) }
+          def supplemental_groups(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def supplemental_groups_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/policy/v1beta1/se_linux_strategy_options.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/policy/v1beta1/se_linux_strategy_options.rbi
@@ -22,8 +22,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def rule(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::SELinuxOptions) }
-          def se_linux_options; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::SELinuxOptions).void)).returns(KubeDSL::DSL::V1::SELinuxOptions) }
+          def se_linux_options(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def se_linux_options_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/rbac/v1/cluster_role.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/rbac/v1/cluster_role.rbi
@@ -19,16 +19,16 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Rbac::V1::AggregationRule) }
-          def aggregation_rule; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Rbac::V1::AggregationRule).void)).returns(KubeDSL::DSL::Rbac::V1::AggregationRule) }
+          def aggregation_rule(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def aggregation_rule_present?; end
 
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/rbac/v1/cluster_role_binding.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/rbac/v1/cluster_role_binding.rbi
@@ -21,14 +21,14 @@ module KubeDSL
 
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Rbac::V1::RoleRef) }
-          def role_ref; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Rbac::V1::RoleRef).void)).returns(KubeDSL::DSL::Rbac::V1::RoleRef) }
+          def role_ref(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def role_ref_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/rbac/v1/cluster_role_binding_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/rbac/v1/cluster_role_binding_list.rbi
@@ -29,8 +29,8 @@ module KubeDSL
           def items(elem_name = nil, &block); end
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/rbac/v1/cluster_role_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/rbac/v1/cluster_role_list.rbi
@@ -29,8 +29,8 @@ module KubeDSL
           def items(elem_name = nil, &block); end
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/rbac/v1/role.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/rbac/v1/role.rbi
@@ -21,8 +21,8 @@ module KubeDSL
 
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/rbac/v1/role_binding.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/rbac/v1/role_binding.rbi
@@ -21,14 +21,14 @@ module KubeDSL
 
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Rbac::V1::RoleRef) }
-          def role_ref; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Rbac::V1::RoleRef).void)).returns(KubeDSL::DSL::Rbac::V1::RoleRef) }
+          def role_ref(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def role_ref_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/rbac/v1/role_binding_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/rbac/v1/role_binding_list.rbi
@@ -29,8 +29,8 @@ module KubeDSL
           def items(elem_name = nil, &block); end
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/rbac/v1/role_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/rbac/v1/role_list.rbi
@@ -29,8 +29,8 @@ module KubeDSL
           def items(elem_name = nil, &block); end
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/scheduling/v1/priority_class.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/scheduling/v1/priority_class.rbi
@@ -27,8 +27,8 @@ module KubeDSL
           def global_default(val = nil); end
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/scheduling/v1/priority_class_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/scheduling/v1/priority_class_list.rbi
@@ -29,8 +29,8 @@ module KubeDSL
           def items(elem_name = nil, &block); end
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/storage/v1/csi_driver.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/storage/v1/csi_driver.rbi
@@ -21,14 +21,14 @@ module KubeDSL
 
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Storage::V1::CSIDriverSpec) }
-          def spec; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Storage::V1::CSIDriverSpec).void)).returns(KubeDSL::DSL::Storage::V1::CSIDriverSpec) }
+          def spec(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def spec_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/storage/v1/csi_driver_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/storage/v1/csi_driver_list.rbi
@@ -29,8 +29,8 @@ module KubeDSL
           def items(elem_name = nil, &block); end
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/storage/v1/csi_node.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/storage/v1/csi_node.rbi
@@ -21,14 +21,14 @@ module KubeDSL
 
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Storage::V1::CSINodeSpec) }
-          def spec; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Storage::V1::CSINodeSpec).void)).returns(KubeDSL::DSL::Storage::V1::CSINodeSpec) }
+          def spec(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def spec_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/storage/v1/csi_node_driver.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/storage/v1/csi_node_driver.rbi
@@ -19,8 +19,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Storage::V1::VolumeNodeResources) }
-          def allocatable; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Storage::V1::VolumeNodeResources).void)).returns(KubeDSL::DSL::Storage::V1::VolumeNodeResources) }
+          def allocatable(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def allocatable_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/storage/v1/csi_node_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/storage/v1/csi_node_list.rbi
@@ -29,8 +29,8 @@ module KubeDSL
           def items(elem_name = nil, &block); end
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/storage/v1/storage_class.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/storage/v1/storage_class.rbi
@@ -32,8 +32,8 @@ module KubeDSL
 
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end
@@ -41,7 +41,7 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def mount_options(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
           def parameters(&block); end
 
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }

--- a/sorbet/rbi/kube-dsl/dsl/storage/v1/storage_class_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/storage/v1/storage_class_list.rbi
@@ -29,8 +29,8 @@ module KubeDSL
           def items(elem_name = nil, &block); end
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/storage/v1/volume_attachment.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/storage/v1/volume_attachment.rbi
@@ -21,20 +21,20 @@ module KubeDSL
 
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Storage::V1::VolumeAttachmentSpec) }
-          def spec; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Storage::V1::VolumeAttachmentSpec).void)).returns(KubeDSL::DSL::Storage::V1::VolumeAttachmentSpec) }
+          def spec(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def spec_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Storage::V1::VolumeAttachmentStatus) }
-          def status; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Storage::V1::VolumeAttachmentStatus).void)).returns(KubeDSL::DSL::Storage::V1::VolumeAttachmentStatus) }
+          def status(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def status_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/storage/v1/volume_attachment_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/storage/v1/volume_attachment_list.rbi
@@ -29,8 +29,8 @@ module KubeDSL
           def items(elem_name = nil, &block); end
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/storage/v1/volume_attachment_source.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/storage/v1/volume_attachment_source.rbi
@@ -19,8 +19,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::PersistentVolumeSpec) }
-          def inline_volume_spec; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PersistentVolumeSpec).void)).returns(KubeDSL::DSL::V1::PersistentVolumeSpec) }
+          def inline_volume_spec(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def inline_volume_spec_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/storage/v1/volume_attachment_spec.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/storage/v1/volume_attachment_spec.rbi
@@ -25,8 +25,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def node_name(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Storage::V1::VolumeAttachmentSource) }
-          def source; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Storage::V1::VolumeAttachmentSource).void)).returns(KubeDSL::DSL::Storage::V1::VolumeAttachmentSource) }
+          def source(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def source_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/storage/v1/volume_attachment_status.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/storage/v1/volume_attachment_status.rbi
@@ -19,8 +19,8 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { returns(Symbol) }
           def kind_sym; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Storage::V1::VolumeError) }
-          def attach_error; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Storage::V1::VolumeError).void)).returns(KubeDSL::DSL::Storage::V1::VolumeError) }
+          def attach_error(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def attach_error_present?; end
@@ -28,11 +28,11 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(T::Boolean)).returns(T::Boolean) }
           def attached(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
           def attachment_metadata(&block); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Storage::V1::VolumeError) }
-          def detach_error; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Storage::V1::VolumeError).void)).returns(KubeDSL::DSL::Storage::V1::VolumeError) }
+          def detach_error(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def detach_error_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/storage/v1alpha1/csi_storage_capacity.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/storage/v1alpha1/csi_storage_capacity.rbi
@@ -27,14 +27,14 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def maximum_volume_size(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-          def node_topology; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+          def node_topology(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def node_topology_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/storage/v1alpha1/csi_storage_capacity_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/storage/v1alpha1/csi_storage_capacity_list.rbi
@@ -29,8 +29,8 @@ module KubeDSL
           def items(elem_name = nil, &block); end
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/storage/v1beta1/csi_storage_capacity.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/storage/v1beta1/csi_storage_capacity.rbi
@@ -27,14 +27,14 @@ module KubeDSL
           T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
           def maximum_volume_size(val = nil); end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-          def node_topology; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+          def node_topology(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def node_topology_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/storage/v1beta1/csi_storage_capacity_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/storage/v1beta1/csi_storage_capacity_list.rbi
@@ -29,8 +29,8 @@ module KubeDSL
           def items(elem_name = nil, &block); end
 
 
-          T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-          def metadata; end
+          T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+          def metadata(&block); end
           
           T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
           def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/affinity.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/affinity.rbi
@@ -18,20 +18,20 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { returns(Symbol) }
         def kind_sym; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::NodeAffinity) }
-        def node_affinity; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::NodeAffinity).void)).returns(KubeDSL::DSL::V1::NodeAffinity) }
+        def node_affinity(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def node_affinity_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::PodAffinity) }
-        def pod_affinity; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PodAffinity).void)).returns(KubeDSL::DSL::V1::PodAffinity) }
+        def pod_affinity(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def pod_affinity_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::PodAntiAffinity) }
-        def pod_anti_affinity; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PodAntiAffinity).void)).returns(KubeDSL::DSL::V1::PodAntiAffinity) }
+        def pod_anti_affinity(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def pod_anti_affinity_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/binding.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/binding.rbi
@@ -20,14 +20,14 @@ module KubeDSL
 
 
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-        def metadata; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+        def metadata(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def metadata_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::ObjectReference) }
-        def target; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ObjectReference).void)).returns(KubeDSL::DSL::V1::ObjectReference) }
+        def target(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def target_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/ceph_fs_persistent_volume_source.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/ceph_fs_persistent_volume_source.rbi
@@ -30,8 +30,8 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
         def secret_file(val = nil); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::SecretReference) }
-        def secret_ref; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::SecretReference).void)).returns(KubeDSL::DSL::V1::SecretReference) }
+        def secret_ref(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def secret_ref_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/ceph_fs_volume_source.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/ceph_fs_volume_source.rbi
@@ -30,8 +30,8 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
         def secret_file(val = nil); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::LocalObjectReference) }
-        def secret_ref; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::LocalObjectReference).void)).returns(KubeDSL::DSL::V1::LocalObjectReference) }
+        def secret_ref(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def secret_ref_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/cinder_persistent_volume_source.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/cinder_persistent_volume_source.rbi
@@ -24,8 +24,8 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(T::Boolean)).returns(T::Boolean) }
         def read_only(val = nil); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::SecretReference) }
-        def secret_ref; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::SecretReference).void)).returns(KubeDSL::DSL::V1::SecretReference) }
+        def secret_ref(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def secret_ref_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/cinder_volume_source.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/cinder_volume_source.rbi
@@ -24,8 +24,8 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(T::Boolean)).returns(T::Boolean) }
         def read_only(val = nil); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::LocalObjectReference) }
-        def secret_ref; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::LocalObjectReference).void)).returns(KubeDSL::DSL::V1::LocalObjectReference) }
+        def secret_ref(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def secret_ref_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/component_status.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/component_status.rbi
@@ -28,8 +28,8 @@ module KubeDSL
         def conditions(elem_name = nil, &block); end
 
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-        def metadata; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+        def metadata(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/component_status_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/component_status_list.rbi
@@ -28,8 +28,8 @@ module KubeDSL
         def items(elem_name = nil, &block); end
 
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-        def metadata; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+        def metadata(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/config_map.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/config_map.rbi
@@ -19,18 +19,18 @@ module KubeDSL
         def kind_sym; end
 
 
-        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
         def binary_data(&block); end
 
-        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
         def data(&block); end
 
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(T::Boolean)).returns(T::Boolean) }
         def immutable(val = nil); end
 
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-        def metadata; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+        def metadata(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/config_map_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/config_map_list.rbi
@@ -28,8 +28,8 @@ module KubeDSL
         def items(elem_name = nil, &block); end
 
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-        def metadata; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+        def metadata(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/container.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/container.rbi
@@ -46,14 +46,14 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
         def image_pull_policy(val = nil); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::Lifecycle) }
-        def lifecycle; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::Lifecycle).void)).returns(KubeDSL::DSL::V1::Lifecycle) }
+        def lifecycle(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def lifecycle_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::Probe) }
-        def liveness_probe; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::Probe).void)).returns(KubeDSL::DSL::V1::Probe) }
+        def liveness_probe(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def liveness_probe_present?; end
@@ -69,26 +69,26 @@ module KubeDSL
         }
         def ports(elem_name = nil, &block); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::Probe) }
-        def readiness_probe; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::Probe).void)).returns(KubeDSL::DSL::V1::Probe) }
+        def readiness_probe(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def readiness_probe_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::ResourceRequirements) }
-        def resources; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ResourceRequirements).void)).returns(KubeDSL::DSL::V1::ResourceRequirements) }
+        def resources(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def resources_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::SecurityContext) }
-        def security_context; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::SecurityContext).void)).returns(KubeDSL::DSL::V1::SecurityContext) }
+        def security_context(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def security_context_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::Probe) }
-        def startup_probe; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::Probe).void)).returns(KubeDSL::DSL::V1::Probe) }
+        def startup_probe(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def startup_probe_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/container_state.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/container_state.rbi
@@ -18,20 +18,20 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { returns(Symbol) }
         def kind_sym; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::ContainerStateRunning) }
-        def running; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ContainerStateRunning).void)).returns(KubeDSL::DSL::V1::ContainerStateRunning) }
+        def running(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def running_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::ContainerStateTerminated) }
-        def terminated; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ContainerStateTerminated).void)).returns(KubeDSL::DSL::V1::ContainerStateTerminated) }
+        def terminated(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def terminated_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::ContainerStateWaiting) }
-        def waiting; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ContainerStateWaiting).void)).returns(KubeDSL::DSL::V1::ContainerStateWaiting) }
+        def waiting(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def waiting_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/container_status.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/container_status.rbi
@@ -27,8 +27,8 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
         def image_id(val = nil); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::ContainerState) }
-        def last_state; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ContainerState).void)).returns(KubeDSL::DSL::V1::ContainerState) }
+        def last_state(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def last_state_present?; end
@@ -45,8 +45,8 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(T::Boolean)).returns(T::Boolean) }
         def started(val = nil); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::ContainerState) }
-        def state; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ContainerState).void)).returns(KubeDSL::DSL::V1::ContainerState) }
+        def state(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def state_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/csi_persistent_volume_source.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/csi_persistent_volume_source.rbi
@@ -18,14 +18,14 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { returns(Symbol) }
         def kind_sym; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::SecretReference) }
-        def controller_expand_secret_ref; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::SecretReference).void)).returns(KubeDSL::DSL::V1::SecretReference) }
+        def controller_expand_secret_ref(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def controller_expand_secret_ref_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::SecretReference) }
-        def controller_publish_secret_ref; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::SecretReference).void)).returns(KubeDSL::DSL::V1::SecretReference) }
+        def controller_publish_secret_ref(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def controller_publish_secret_ref_present?; end
@@ -36,14 +36,14 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
         def fs_type(val = nil); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::SecretReference) }
-        def node_publish_secret_ref; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::SecretReference).void)).returns(KubeDSL::DSL::V1::SecretReference) }
+        def node_publish_secret_ref(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def node_publish_secret_ref_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::SecretReference) }
-        def node_stage_secret_ref; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::SecretReference).void)).returns(KubeDSL::DSL::V1::SecretReference) }
+        def node_stage_secret_ref(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def node_stage_secret_ref_present?; end
@@ -51,7 +51,7 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(T::Boolean)).returns(T::Boolean) }
         def read_only(val = nil); end
 
-        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
         def volume_attributes(&block); end
 
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }

--- a/sorbet/rbi/kube-dsl/dsl/v1/csi_volume_source.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/csi_volume_source.rbi
@@ -24,8 +24,8 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
         def fs_type(val = nil); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::LocalObjectReference) }
-        def node_publish_secret_ref; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::LocalObjectReference).void)).returns(KubeDSL::DSL::V1::LocalObjectReference) }
+        def node_publish_secret_ref(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def node_publish_secret_ref_present?; end
@@ -33,7 +33,7 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(T::Boolean)).returns(T::Boolean) }
         def read_only(val = nil); end
 
-        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
         def volume_attributes(&block); end
       end
     end

--- a/sorbet/rbi/kube-dsl/dsl/v1/downward_api_volume_file.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/downward_api_volume_file.rbi
@@ -18,8 +18,8 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { returns(Symbol) }
         def kind_sym; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::ObjectFieldSelector) }
-        def field_ref; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ObjectFieldSelector).void)).returns(KubeDSL::DSL::V1::ObjectFieldSelector) }
+        def field_ref(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def field_ref_present?; end
@@ -30,8 +30,8 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
         def path(val = nil); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::ResourceFieldSelector) }
-        def resource_field_ref; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ResourceFieldSelector).void)).returns(KubeDSL::DSL::V1::ResourceFieldSelector) }
+        def resource_field_ref(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def resource_field_ref_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/endpoint_address.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/endpoint_address.rbi
@@ -27,8 +27,8 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
         def node_name(val = nil); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::ObjectReference) }
-        def target_ref; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ObjectReference).void)).returns(KubeDSL::DSL::V1::ObjectReference) }
+        def target_ref(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def target_ref_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/endpoints.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/endpoints.rbi
@@ -20,8 +20,8 @@ module KubeDSL
 
 
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-        def metadata; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+        def metadata(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/endpoints_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/endpoints_list.rbi
@@ -28,8 +28,8 @@ module KubeDSL
         def items(elem_name = nil, &block); end
 
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-        def metadata; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+        def metadata(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/env_from_source.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/env_from_source.rbi
@@ -18,8 +18,8 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { returns(Symbol) }
         def kind_sym; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::ConfigMapEnvSource) }
-        def config_map_ref; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ConfigMapEnvSource).void)).returns(KubeDSL::DSL::V1::ConfigMapEnvSource) }
+        def config_map_ref(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def config_map_ref_present?; end
@@ -27,8 +27,8 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
         def prefix(val = nil); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::SecretEnvSource) }
-        def secret_ref; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::SecretEnvSource).void)).returns(KubeDSL::DSL::V1::SecretEnvSource) }
+        def secret_ref(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def secret_ref_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/env_var.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/env_var.rbi
@@ -24,8 +24,8 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
         def value(val = nil); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::EnvVarSource) }
-        def value_from; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::EnvVarSource).void)).returns(KubeDSL::DSL::V1::EnvVarSource) }
+        def value_from(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def value_from_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/env_var_source.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/env_var_source.rbi
@@ -18,26 +18,26 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { returns(Symbol) }
         def kind_sym; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::ConfigMapKeySelector) }
-        def config_map_key_ref; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ConfigMapKeySelector).void)).returns(KubeDSL::DSL::V1::ConfigMapKeySelector) }
+        def config_map_key_ref(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def config_map_key_ref_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::ObjectFieldSelector) }
-        def field_ref; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ObjectFieldSelector).void)).returns(KubeDSL::DSL::V1::ObjectFieldSelector) }
+        def field_ref(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def field_ref_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::ResourceFieldSelector) }
-        def resource_field_ref; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ResourceFieldSelector).void)).returns(KubeDSL::DSL::V1::ResourceFieldSelector) }
+        def resource_field_ref(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def resource_field_ref_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::SecretKeySelector) }
-        def secret_key_ref; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::SecretKeySelector).void)).returns(KubeDSL::DSL::V1::SecretKeySelector) }
+        def secret_key_ref(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def secret_key_ref_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/ephemeral_container.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/ephemeral_container.rbi
@@ -46,14 +46,14 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
         def image_pull_policy(val = nil); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::Lifecycle) }
-        def lifecycle; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::Lifecycle).void)).returns(KubeDSL::DSL::V1::Lifecycle) }
+        def lifecycle(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def lifecycle_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::Probe) }
-        def liveness_probe; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::Probe).void)).returns(KubeDSL::DSL::V1::Probe) }
+        def liveness_probe(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def liveness_probe_present?; end
@@ -69,26 +69,26 @@ module KubeDSL
         }
         def ports(elem_name = nil, &block); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::Probe) }
-        def readiness_probe; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::Probe).void)).returns(KubeDSL::DSL::V1::Probe) }
+        def readiness_probe(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def readiness_probe_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::ResourceRequirements) }
-        def resources; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ResourceRequirements).void)).returns(KubeDSL::DSL::V1::ResourceRequirements) }
+        def resources(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def resources_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::SecurityContext) }
-        def security_context; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::SecurityContext).void)).returns(KubeDSL::DSL::V1::SecurityContext) }
+        def security_context(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def security_context_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::Probe) }
-        def startup_probe; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::Probe).void)).returns(KubeDSL::DSL::V1::Probe) }
+        def startup_probe(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def startup_probe_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/ephemeral_volume_source.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/ephemeral_volume_source.rbi
@@ -18,8 +18,8 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { returns(Symbol) }
         def kind_sym; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::PersistentVolumeClaimTemplate) }
-        def volume_claim_template; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PersistentVolumeClaimTemplate).void)).returns(KubeDSL::DSL::V1::PersistentVolumeClaimTemplate) }
+        def volume_claim_template(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def volume_claim_template_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/event.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/event.rbi
@@ -31,8 +31,8 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
         def first_timestamp(val = nil); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::ObjectReference) }
-        def involved_object; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ObjectReference).void)).returns(KubeDSL::DSL::V1::ObjectReference) }
+        def involved_object(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def involved_object_present?; end
@@ -44,8 +44,8 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
         def message(val = nil); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-        def metadata; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+        def metadata(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def metadata_present?; end
@@ -53,8 +53,8 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
         def reason(val = nil); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::ObjectReference) }
-        def related; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ObjectReference).void)).returns(KubeDSL::DSL::V1::ObjectReference) }
+        def related(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def related_present?; end
@@ -65,14 +65,14 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
         def reporting_instance(val = nil); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::EventSeries) }
-        def series; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::EventSeries).void)).returns(KubeDSL::DSL::V1::EventSeries) }
+        def series(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def series_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::EventSource) }
-        def source; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::EventSource).void)).returns(KubeDSL::DSL::V1::EventSource) }
+        def source(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def source_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/event_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/event_list.rbi
@@ -28,8 +28,8 @@ module KubeDSL
         def items(elem_name = nil, &block); end
 
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-        def metadata; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+        def metadata(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/flex_persistent_volume_source.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/flex_persistent_volume_source.rbi
@@ -24,14 +24,14 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
         def fs_type(val = nil); end
 
-        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
         def options(&block); end
 
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(T::Boolean)).returns(T::Boolean) }
         def read_only(val = nil); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::SecretReference) }
-        def secret_ref; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::SecretReference).void)).returns(KubeDSL::DSL::V1::SecretReference) }
+        def secret_ref(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def secret_ref_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/flex_volume_source.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/flex_volume_source.rbi
@@ -24,14 +24,14 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
         def fs_type(val = nil); end
 
-        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
         def options(&block); end
 
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(T::Boolean)).returns(T::Boolean) }
         def read_only(val = nil); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::LocalObjectReference) }
-        def secret_ref; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::LocalObjectReference).void)).returns(KubeDSL::DSL::V1::LocalObjectReference) }
+        def secret_ref(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def secret_ref_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/iscsi_persistent_volume_source.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/iscsi_persistent_volume_source.rbi
@@ -45,8 +45,8 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(T::Boolean)).returns(T::Boolean) }
         def read_only(val = nil); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::SecretReference) }
-        def secret_ref; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::SecretReference).void)).returns(KubeDSL::DSL::V1::SecretReference) }
+        def secret_ref(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def secret_ref_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/iscsi_volume_source.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/iscsi_volume_source.rbi
@@ -45,8 +45,8 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(T::Boolean)).returns(T::Boolean) }
         def read_only(val = nil); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::LocalObjectReference) }
-        def secret_ref; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::LocalObjectReference).void)).returns(KubeDSL::DSL::V1::LocalObjectReference) }
+        def secret_ref(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def secret_ref_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/lifecycle.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/lifecycle.rbi
@@ -18,14 +18,14 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { returns(Symbol) }
         def kind_sym; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::LifecycleHandler) }
-        def post_start; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::LifecycleHandler).void)).returns(KubeDSL::DSL::V1::LifecycleHandler) }
+        def post_start(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def post_start_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::LifecycleHandler) }
-        def pre_stop; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::LifecycleHandler).void)).returns(KubeDSL::DSL::V1::LifecycleHandler) }
+        def pre_stop(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def pre_stop_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/lifecycle_handler.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/lifecycle_handler.rbi
@@ -18,20 +18,20 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { returns(Symbol) }
         def kind_sym; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::ExecAction) }
-        def exec; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ExecAction).void)).returns(KubeDSL::DSL::V1::ExecAction) }
+        def exec(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def exec_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::HTTPGetAction) }
-        def http_get; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::HTTPGetAction).void)).returns(KubeDSL::DSL::V1::HTTPGetAction) }
+        def http_get(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def http_get_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::TCPSocketAction) }
-        def tcp_socket; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::TCPSocketAction).void)).returns(KubeDSL::DSL::V1::TCPSocketAction) }
+        def tcp_socket(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def tcp_socket_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/limit_range.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/limit_range.rbi
@@ -20,14 +20,14 @@ module KubeDSL
 
 
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-        def metadata; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+        def metadata(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def metadata_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::LimitRangeSpec) }
-        def spec; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::LimitRangeSpec).void)).returns(KubeDSL::DSL::V1::LimitRangeSpec) }
+        def spec(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def spec_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/limit_range_item.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/limit_range_item.rbi
@@ -18,19 +18,19 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { returns(Symbol) }
         def kind_sym; end
 
-        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
         def default(&block); end
 
-        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
         def default_request(&block); end
 
-        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
         def max(&block); end
 
-        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
         def max_limit_request_ratio(&block); end
 
-        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
         def min(&block); end
 
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }

--- a/sorbet/rbi/kube-dsl/dsl/v1/limit_range_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/limit_range_list.rbi
@@ -28,8 +28,8 @@ module KubeDSL
         def items(elem_name = nil, &block); end
 
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-        def metadata; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+        def metadata(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/namespace.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/namespace.rbi
@@ -20,20 +20,20 @@ module KubeDSL
 
 
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-        def metadata; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+        def metadata(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def metadata_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::NamespaceSpec) }
-        def spec; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::NamespaceSpec).void)).returns(KubeDSL::DSL::V1::NamespaceSpec) }
+        def spec(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def spec_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::NamespaceStatus) }
-        def status; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::NamespaceStatus).void)).returns(KubeDSL::DSL::V1::NamespaceStatus) }
+        def status(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def status_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/namespace_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/namespace_list.rbi
@@ -28,8 +28,8 @@ module KubeDSL
         def items(elem_name = nil, &block); end
 
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-        def metadata; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+        def metadata(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/node.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/node.rbi
@@ -20,20 +20,20 @@ module KubeDSL
 
 
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-        def metadata; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+        def metadata(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def metadata_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::NodeSpec) }
-        def spec; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::NodeSpec).void)).returns(KubeDSL::DSL::V1::NodeSpec) }
+        def spec(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def spec_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::NodeStatus) }
-        def status; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::NodeStatus).void)).returns(KubeDSL::DSL::V1::NodeStatus) }
+        def status(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def status_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/node_affinity.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/node_affinity.rbi
@@ -26,8 +26,8 @@ module KubeDSL
         }
         def preferred_during_scheduling_ignored_during_executions(elem_name = nil, &block); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::NodeSelector) }
-        def required_during_scheduling_ignored_during_execution; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::NodeSelector).void)).returns(KubeDSL::DSL::V1::NodeSelector) }
+        def required_during_scheduling_ignored_during_execution(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def required_during_scheduling_ignored_during_execution_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/node_config_source.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/node_config_source.rbi
@@ -18,8 +18,8 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { returns(Symbol) }
         def kind_sym; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::ConfigMapNodeConfigSource) }
-        def config_map; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ConfigMapNodeConfigSource).void)).returns(KubeDSL::DSL::V1::ConfigMapNodeConfigSource) }
+        def config_map(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def config_map_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/node_config_status.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/node_config_status.rbi
@@ -18,14 +18,14 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { returns(Symbol) }
         def kind_sym; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::NodeConfigSource) }
-        def active; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::NodeConfigSource).void)).returns(KubeDSL::DSL::V1::NodeConfigSource) }
+        def active(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def active_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::NodeConfigSource) }
-        def assigned; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::NodeConfigSource).void)).returns(KubeDSL::DSL::V1::NodeConfigSource) }
+        def assigned(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def assigned_present?; end
@@ -33,8 +33,8 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
         def error(val = nil); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::NodeConfigSource) }
-        def last_known_good; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::NodeConfigSource).void)).returns(KubeDSL::DSL::V1::NodeConfigSource) }
+        def last_known_good(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def last_known_good_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/node_daemon_endpoints.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/node_daemon_endpoints.rbi
@@ -18,8 +18,8 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { returns(Symbol) }
         def kind_sym; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::DaemonEndpoint) }
-        def kubelet_endpoint; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::DaemonEndpoint).void)).returns(KubeDSL::DSL::V1::DaemonEndpoint) }
+        def kubelet_endpoint(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def kubelet_endpoint_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/node_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/node_list.rbi
@@ -28,8 +28,8 @@ module KubeDSL
         def items(elem_name = nil, &block); end
 
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-        def metadata; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+        def metadata(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/node_spec.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/node_spec.rbi
@@ -18,8 +18,8 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { returns(Symbol) }
         def kind_sym; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::NodeConfigSource) }
-        def config_source; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::NodeConfigSource).void)).returns(KubeDSL::DSL::V1::NodeConfigSource) }
+        def config_source(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def config_source_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/node_status.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/node_status.rbi
@@ -26,10 +26,10 @@ module KubeDSL
         }
         def addresses(elem_name = nil, &block); end
 
-        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
         def allocatable(&block); end
 
-        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
         def capacity(&block); end
 
         T::Sig::WithoutRuntime.sig {
@@ -40,14 +40,14 @@ module KubeDSL
         }
         def conditions(elem_name = nil, &block); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::NodeConfigStatus) }
-        def config; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::NodeConfigStatus).void)).returns(KubeDSL::DSL::V1::NodeConfigStatus) }
+        def config(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def config_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::NodeDaemonEndpoints) }
-        def daemon_endpoints; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::NodeDaemonEndpoints).void)).returns(KubeDSL::DSL::V1::NodeDaemonEndpoints) }
+        def daemon_endpoints(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def daemon_endpoints_present?; end
@@ -60,8 +60,8 @@ module KubeDSL
         }
         def images(elem_name = nil, &block); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::NodeSystemInfo) }
-        def node_info; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::NodeSystemInfo).void)).returns(KubeDSL::DSL::V1::NodeSystemInfo) }
+        def node_info(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def node_info_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/persistent_volume.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/persistent_volume.rbi
@@ -20,20 +20,20 @@ module KubeDSL
 
 
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-        def metadata; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+        def metadata(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def metadata_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::PersistentVolumeSpec) }
-        def spec; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PersistentVolumeSpec).void)).returns(KubeDSL::DSL::V1::PersistentVolumeSpec) }
+        def spec(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def spec_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::PersistentVolumeStatus) }
-        def status; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PersistentVolumeStatus).void)).returns(KubeDSL::DSL::V1::PersistentVolumeStatus) }
+        def status(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def status_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/persistent_volume_claim.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/persistent_volume_claim.rbi
@@ -20,20 +20,20 @@ module KubeDSL
 
 
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-        def metadata; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+        def metadata(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def metadata_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::PersistentVolumeClaimSpec) }
-        def spec; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PersistentVolumeClaimSpec).void)).returns(KubeDSL::DSL::V1::PersistentVolumeClaimSpec) }
+        def spec(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def spec_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::PersistentVolumeClaimStatus) }
-        def status; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PersistentVolumeClaimStatus).void)).returns(KubeDSL::DSL::V1::PersistentVolumeClaimStatus) }
+        def status(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def status_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/persistent_volume_claim_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/persistent_volume_claim_list.rbi
@@ -28,8 +28,8 @@ module KubeDSL
         def items(elem_name = nil, &block); end
 
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-        def metadata; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+        def metadata(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/persistent_volume_claim_spec.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/persistent_volume_claim_spec.rbi
@@ -21,26 +21,26 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
         def access_modes(val = nil); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::TypedLocalObjectReference) }
-        def data_source; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::TypedLocalObjectReference).void)).returns(KubeDSL::DSL::V1::TypedLocalObjectReference) }
+        def data_source(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def data_source_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::TypedLocalObjectReference) }
-        def data_source_ref; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::TypedLocalObjectReference).void)).returns(KubeDSL::DSL::V1::TypedLocalObjectReference) }
+        def data_source_ref(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def data_source_ref_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::ResourceRequirements) }
-        def resources; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ResourceRequirements).void)).returns(KubeDSL::DSL::V1::ResourceRequirements) }
+        def resources(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def resources_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-        def selector; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+        def selector(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def selector_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/persistent_volume_claim_status.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/persistent_volume_claim_status.rbi
@@ -21,10 +21,10 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
         def access_modes(val = nil); end
 
-        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
         def allocated_resources(&block); end
 
-        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
         def capacity(&block); end
 
         T::Sig::WithoutRuntime.sig {

--- a/sorbet/rbi/kube-dsl/dsl/v1/persistent_volume_claim_template.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/persistent_volume_claim_template.rbi
@@ -18,14 +18,14 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { returns(Symbol) }
         def kind_sym; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-        def metadata; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+        def metadata(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def metadata_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::PersistentVolumeClaimSpec) }
-        def spec; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PersistentVolumeClaimSpec).void)).returns(KubeDSL::DSL::V1::PersistentVolumeClaimSpec) }
+        def spec(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def spec_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/persistent_volume_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/persistent_volume_list.rbi
@@ -28,8 +28,8 @@ module KubeDSL
         def items(elem_name = nil, &block); end
 
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-        def metadata; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+        def metadata(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/persistent_volume_spec.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/persistent_volume_spec.rbi
@@ -21,95 +21,95 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
         def access_modes(val = nil); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::AWSElasticBlockStoreVolumeSource) }
-        def aws_elastic_block_store; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::AWSElasticBlockStoreVolumeSource).void)).returns(KubeDSL::DSL::V1::AWSElasticBlockStoreVolumeSource) }
+        def aws_elastic_block_store(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def aws_elastic_block_store_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::AzureDiskVolumeSource) }
-        def azure_disk; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::AzureDiskVolumeSource).void)).returns(KubeDSL::DSL::V1::AzureDiskVolumeSource) }
+        def azure_disk(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def azure_disk_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::AzureFilePersistentVolumeSource) }
-        def azure_file; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::AzureFilePersistentVolumeSource).void)).returns(KubeDSL::DSL::V1::AzureFilePersistentVolumeSource) }
+        def azure_file(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def azure_file_present?; end
 
-        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
         def capacity(&block); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::CephFSPersistentVolumeSource) }
-        def cephfs; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::CephFSPersistentVolumeSource).void)).returns(KubeDSL::DSL::V1::CephFSPersistentVolumeSource) }
+        def cephfs(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def cephfs_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::CinderPersistentVolumeSource) }
-        def cinder; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::CinderPersistentVolumeSource).void)).returns(KubeDSL::DSL::V1::CinderPersistentVolumeSource) }
+        def cinder(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def cinder_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::ObjectReference) }
-        def claim_ref; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ObjectReference).void)).returns(KubeDSL::DSL::V1::ObjectReference) }
+        def claim_ref(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def claim_ref_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::CSIPersistentVolumeSource) }
-        def csi; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::CSIPersistentVolumeSource).void)).returns(KubeDSL::DSL::V1::CSIPersistentVolumeSource) }
+        def csi(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def csi_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::FCVolumeSource) }
-        def fc; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::FCVolumeSource).void)).returns(KubeDSL::DSL::V1::FCVolumeSource) }
+        def fc(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def fc_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::FlexPersistentVolumeSource) }
-        def flex_volume; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::FlexPersistentVolumeSource).void)).returns(KubeDSL::DSL::V1::FlexPersistentVolumeSource) }
+        def flex_volume(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def flex_volume_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::FlockerVolumeSource) }
-        def flocker; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::FlockerVolumeSource).void)).returns(KubeDSL::DSL::V1::FlockerVolumeSource) }
+        def flocker(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def flocker_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::GCEPersistentDiskVolumeSource) }
-        def gce_persistent_disk; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::GCEPersistentDiskVolumeSource).void)).returns(KubeDSL::DSL::V1::GCEPersistentDiskVolumeSource) }
+        def gce_persistent_disk(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def gce_persistent_disk_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::GlusterfsPersistentVolumeSource) }
-        def glusterfs; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::GlusterfsPersistentVolumeSource).void)).returns(KubeDSL::DSL::V1::GlusterfsPersistentVolumeSource) }
+        def glusterfs(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def glusterfs_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::HostPathVolumeSource) }
-        def host_path; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::HostPathVolumeSource).void)).returns(KubeDSL::DSL::V1::HostPathVolumeSource) }
+        def host_path(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def host_path_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::ISCSIPersistentVolumeSource) }
-        def iscsi; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ISCSIPersistentVolumeSource).void)).returns(KubeDSL::DSL::V1::ISCSIPersistentVolumeSource) }
+        def iscsi(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def iscsi_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::LocalVolumeSource) }
-        def local; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::LocalVolumeSource).void)).returns(KubeDSL::DSL::V1::LocalVolumeSource) }
+        def local(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def local_present?; end
@@ -117,14 +117,14 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
         def mount_options(val = nil); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::NFSVolumeSource) }
-        def nfs; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::NFSVolumeSource).void)).returns(KubeDSL::DSL::V1::NFSVolumeSource) }
+        def nfs(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def nfs_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::VolumeNodeAffinity) }
-        def node_affinity; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::VolumeNodeAffinity).void)).returns(KubeDSL::DSL::V1::VolumeNodeAffinity) }
+        def node_affinity(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def node_affinity_present?; end
@@ -132,32 +132,32 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
         def persistent_volume_reclaim_policy(val = nil); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::PhotonPersistentDiskVolumeSource) }
-        def photon_persistent_disk; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PhotonPersistentDiskVolumeSource).void)).returns(KubeDSL::DSL::V1::PhotonPersistentDiskVolumeSource) }
+        def photon_persistent_disk(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def photon_persistent_disk_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::PortworxVolumeSource) }
-        def portworx_volume; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PortworxVolumeSource).void)).returns(KubeDSL::DSL::V1::PortworxVolumeSource) }
+        def portworx_volume(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def portworx_volume_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::QuobyteVolumeSource) }
-        def quobyte; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::QuobyteVolumeSource).void)).returns(KubeDSL::DSL::V1::QuobyteVolumeSource) }
+        def quobyte(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def quobyte_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::RBDPersistentVolumeSource) }
-        def rbd; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::RBDPersistentVolumeSource).void)).returns(KubeDSL::DSL::V1::RBDPersistentVolumeSource) }
+        def rbd(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def rbd_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::ScaleIOPersistentVolumeSource) }
-        def scale_io; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ScaleIOPersistentVolumeSource).void)).returns(KubeDSL::DSL::V1::ScaleIOPersistentVolumeSource) }
+        def scale_io(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def scale_io_present?; end
@@ -165,8 +165,8 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
         def storage_class_name(val = nil); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::StorageOSPersistentVolumeSource) }
-        def storageos; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::StorageOSPersistentVolumeSource).void)).returns(KubeDSL::DSL::V1::StorageOSPersistentVolumeSource) }
+        def storageos(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def storageos_present?; end
@@ -174,8 +174,8 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
         def volume_mode(val = nil); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::VsphereVirtualDiskVolumeSource) }
-        def vsphere_volume; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::VsphereVirtualDiskVolumeSource).void)).returns(KubeDSL::DSL::V1::VsphereVirtualDiskVolumeSource) }
+        def vsphere_volume(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def vsphere_volume_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/pod.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/pod.rbi
@@ -20,20 +20,20 @@ module KubeDSL
 
 
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-        def metadata; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+        def metadata(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def metadata_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::PodSpec) }
-        def spec; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PodSpec).void)).returns(KubeDSL::DSL::V1::PodSpec) }
+        def spec(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def spec_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::PodStatus) }
-        def status; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PodStatus).void)).returns(KubeDSL::DSL::V1::PodStatus) }
+        def status(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def status_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/pod_affinity_term.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/pod_affinity_term.rbi
@@ -18,14 +18,14 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { returns(Symbol) }
         def kind_sym; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-        def label_selector; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+        def label_selector(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def label_selector_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-        def namespace_selector; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+        def namespace_selector(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def namespace_selector_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/pod_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/pod_list.rbi
@@ -28,8 +28,8 @@ module KubeDSL
         def items(elem_name = nil, &block); end
 
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-        def metadata; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+        def metadata(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/pod_security_context.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/pod_security_context.rbi
@@ -33,14 +33,14 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(Integer)).returns(Integer) }
         def run_as_user(val = nil); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::SELinuxOptions) }
-        def se_linux_options; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::SELinuxOptions).void)).returns(KubeDSL::DSL::V1::SELinuxOptions) }
+        def se_linux_options(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def se_linux_options_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::SeccompProfile) }
-        def seccomp_profile; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::SeccompProfile).void)).returns(KubeDSL::DSL::V1::SeccompProfile) }
+        def seccomp_profile(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def seccomp_profile_present?; end
@@ -56,8 +56,8 @@ module KubeDSL
         }
         def sysctlses(elem_name = nil, &block); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::WindowsSecurityContextOptions) }
-        def windows_options; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::WindowsSecurityContextOptions).void)).returns(KubeDSL::DSL::V1::WindowsSecurityContextOptions) }
+        def windows_options(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def windows_options_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/pod_spec.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/pod_spec.rbi
@@ -21,8 +21,8 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(Integer)).returns(Integer) }
         def active_deadline_seconds(val = nil); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::Affinity) }
-        def affinity; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::Affinity).void)).returns(KubeDSL::DSL::V1::Affinity) }
+        def affinity(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def affinity_present?; end
@@ -38,8 +38,8 @@ module KubeDSL
         }
         def containers(elem_name = nil, &block); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::PodDNSConfig) }
-        def dns_config; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PodDNSConfig).void)).returns(KubeDSL::DSL::V1::PodDNSConfig) }
+        def dns_config(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def dns_config_present?; end
@@ -97,16 +97,16 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
         def node_name(val = nil); end
 
-        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
         def node_selector(&block); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::PodOS) }
-        def os; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PodOS).void)).returns(KubeDSL::DSL::V1::PodOS) }
+        def os(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def os_present?; end
 
-        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
         def overhead(&block); end
 
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
@@ -135,8 +135,8 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
         def scheduler_name(val = nil); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::PodSecurityContext) }
-        def security_context; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PodSecurityContext).void)).returns(KubeDSL::DSL::V1::PodSecurityContext) }
+        def security_context(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def security_context_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/pod_template.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/pod_template.rbi
@@ -20,14 +20,14 @@ module KubeDSL
 
 
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-        def metadata; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+        def metadata(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def metadata_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::PodTemplateSpec) }
-        def template; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PodTemplateSpec).void)).returns(KubeDSL::DSL::V1::PodTemplateSpec) }
+        def template(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def template_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/pod_template_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/pod_template_list.rbi
@@ -28,8 +28,8 @@ module KubeDSL
         def items(elem_name = nil, &block); end
 
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-        def metadata; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+        def metadata(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/pod_template_spec.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/pod_template_spec.rbi
@@ -18,14 +18,14 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { returns(Symbol) }
         def kind_sym; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-        def metadata; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+        def metadata(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def metadata_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::PodSpec) }
-        def spec; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PodSpec).void)).returns(KubeDSL::DSL::V1::PodSpec) }
+        def spec(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def spec_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/preferred_scheduling_term.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/preferred_scheduling_term.rbi
@@ -18,8 +18,8 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { returns(Symbol) }
         def kind_sym; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::NodeSelectorTerm) }
-        def preference; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::NodeSelectorTerm).void)).returns(KubeDSL::DSL::V1::NodeSelectorTerm) }
+        def preference(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def preference_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/probe.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/probe.rbi
@@ -18,8 +18,8 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { returns(Symbol) }
         def kind_sym; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::ExecAction) }
-        def exec; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ExecAction).void)).returns(KubeDSL::DSL::V1::ExecAction) }
+        def exec(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def exec_present?; end
@@ -27,14 +27,14 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(Integer)).returns(Integer) }
         def failure_threshold(val = nil); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::GRPCAction) }
-        def grpc; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::GRPCAction).void)).returns(KubeDSL::DSL::V1::GRPCAction) }
+        def grpc(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def grpc_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::HTTPGetAction) }
-        def http_get; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::HTTPGetAction).void)).returns(KubeDSL::DSL::V1::HTTPGetAction) }
+        def http_get(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def http_get_present?; end
@@ -48,8 +48,8 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(Integer)).returns(Integer) }
         def success_threshold(val = nil); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::TCPSocketAction) }
-        def tcp_socket; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::TCPSocketAction).void)).returns(KubeDSL::DSL::V1::TCPSocketAction) }
+        def tcp_socket(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def tcp_socket_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/rbd_persistent_volume_source.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/rbd_persistent_volume_source.rbi
@@ -36,8 +36,8 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(T::Boolean)).returns(T::Boolean) }
         def read_only(val = nil); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::SecretReference) }
-        def secret_ref; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::SecretReference).void)).returns(KubeDSL::DSL::V1::SecretReference) }
+        def secret_ref(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def secret_ref_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/rbd_volume_source.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/rbd_volume_source.rbi
@@ -36,8 +36,8 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(T::Boolean)).returns(T::Boolean) }
         def read_only(val = nil); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::LocalObjectReference) }
-        def secret_ref; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::LocalObjectReference).void)).returns(KubeDSL::DSL::V1::LocalObjectReference) }
+        def secret_ref(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def secret_ref_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/replication_controller.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/replication_controller.rbi
@@ -20,20 +20,20 @@ module KubeDSL
 
 
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-        def metadata; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+        def metadata(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def metadata_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::ReplicationControllerSpec) }
-        def spec; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ReplicationControllerSpec).void)).returns(KubeDSL::DSL::V1::ReplicationControllerSpec) }
+        def spec(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def spec_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::ReplicationControllerStatus) }
-        def status; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ReplicationControllerStatus).void)).returns(KubeDSL::DSL::V1::ReplicationControllerStatus) }
+        def status(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def status_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/replication_controller_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/replication_controller_list.rbi
@@ -28,8 +28,8 @@ module KubeDSL
         def items(elem_name = nil, &block); end
 
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-        def metadata; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+        def metadata(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/replication_controller_spec.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/replication_controller_spec.rbi
@@ -24,11 +24,11 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(Integer)).returns(Integer) }
         def replicas(val = nil); end
 
-        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
         def selector(&block); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::PodTemplateSpec) }
-        def template; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PodTemplateSpec).void)).returns(KubeDSL::DSL::V1::PodTemplateSpec) }
+        def template(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def template_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/resource_quota.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/resource_quota.rbi
@@ -20,20 +20,20 @@ module KubeDSL
 
 
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-        def metadata; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+        def metadata(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def metadata_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::ResourceQuotaSpec) }
-        def spec; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ResourceQuotaSpec).void)).returns(KubeDSL::DSL::V1::ResourceQuotaSpec) }
+        def spec(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def spec_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::ResourceQuotaStatus) }
-        def status; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ResourceQuotaStatus).void)).returns(KubeDSL::DSL::V1::ResourceQuotaStatus) }
+        def status(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def status_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/resource_quota_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/resource_quota_list.rbi
@@ -28,8 +28,8 @@ module KubeDSL
         def items(elem_name = nil, &block); end
 
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-        def metadata; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+        def metadata(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/resource_quota_spec.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/resource_quota_spec.rbi
@@ -18,11 +18,11 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { returns(Symbol) }
         def kind_sym; end
 
-        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
         def hard(&block); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::ScopeSelector) }
-        def scope_selector; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ScopeSelector).void)).returns(KubeDSL::DSL::V1::ScopeSelector) }
+        def scope_selector(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def scope_selector_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/resource_quota_status.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/resource_quota_status.rbi
@@ -18,10 +18,10 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { returns(Symbol) }
         def kind_sym; end
 
-        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
         def hard(&block); end
 
-        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
         def used(&block); end
       end
     end

--- a/sorbet/rbi/kube-dsl/dsl/v1/resource_requirements.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/resource_requirements.rbi
@@ -18,10 +18,10 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { returns(Symbol) }
         def kind_sym; end
 
-        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
         def limits(&block); end
 
-        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
         def requests(&block); end
       end
     end

--- a/sorbet/rbi/kube-dsl/dsl/v1/scale_io_persistent_volume_source.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/scale_io_persistent_volume_source.rbi
@@ -30,8 +30,8 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(T::Boolean)).returns(T::Boolean) }
         def read_only(val = nil); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::SecretReference) }
-        def secret_ref; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::SecretReference).void)).returns(KubeDSL::DSL::V1::SecretReference) }
+        def secret_ref(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def secret_ref_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/scale_io_volume_source.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/scale_io_volume_source.rbi
@@ -30,8 +30,8 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(T::Boolean)).returns(T::Boolean) }
         def read_only(val = nil); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::LocalObjectReference) }
-        def secret_ref; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::LocalObjectReference).void)).returns(KubeDSL::DSL::V1::LocalObjectReference) }
+        def secret_ref(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def secret_ref_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/secret.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/secret.rbi
@@ -19,20 +19,20 @@ module KubeDSL
         def kind_sym; end
 
 
-        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
         def data(&block); end
 
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(T::Boolean)).returns(T::Boolean) }
         def immutable(val = nil); end
 
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-        def metadata; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+        def metadata(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def metadata_present?; end
 
-        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
         def string_data(&block); end
 
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }

--- a/sorbet/rbi/kube-dsl/dsl/v1/secret_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/secret_list.rbi
@@ -28,8 +28,8 @@ module KubeDSL
         def items(elem_name = nil, &block); end
 
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-        def metadata; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+        def metadata(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/security_context.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/security_context.rbi
@@ -21,8 +21,8 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(T::Boolean)).returns(T::Boolean) }
         def allow_privilege_escalation(val = nil); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::Capabilities) }
-        def capabilities; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::Capabilities).void)).returns(KubeDSL::DSL::V1::Capabilities) }
+        def capabilities(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def capabilities_present?; end
@@ -45,20 +45,20 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(Integer)).returns(Integer) }
         def run_as_user(val = nil); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::SELinuxOptions) }
-        def se_linux_options; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::SELinuxOptions).void)).returns(KubeDSL::DSL::V1::SELinuxOptions) }
+        def se_linux_options(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def se_linux_options_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::SeccompProfile) }
-        def seccomp_profile; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::SeccompProfile).void)).returns(KubeDSL::DSL::V1::SeccompProfile) }
+        def seccomp_profile(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def seccomp_profile_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::WindowsSecurityContextOptions) }
-        def windows_options; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::WindowsSecurityContextOptions).void)).returns(KubeDSL::DSL::V1::WindowsSecurityContextOptions) }
+        def windows_options(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def windows_options_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/service.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/service.rbi
@@ -20,20 +20,20 @@ module KubeDSL
 
 
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-        def metadata; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+        def metadata(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def metadata_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::ServiceSpec) }
-        def spec; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ServiceSpec).void)).returns(KubeDSL::DSL::V1::ServiceSpec) }
+        def spec(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def spec_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::ServiceStatus) }
-        def status; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ServiceStatus).void)).returns(KubeDSL::DSL::V1::ServiceStatus) }
+        def status(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def status_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/service_account.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/service_account.rbi
@@ -31,8 +31,8 @@ module KubeDSL
         def image_pull_secrets(elem_name = nil, &block); end
 
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
-        def metadata; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ObjectMeta).void)).returns(KubeDSL::DSL::Meta::V1::ObjectMeta) }
+        def metadata(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/service_account_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/service_account_list.rbi
@@ -28,8 +28,8 @@ module KubeDSL
         def items(elem_name = nil, &block); end
 
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-        def metadata; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+        def metadata(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/service_list.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/service_list.rbi
@@ -28,8 +28,8 @@ module KubeDSL
         def items(elem_name = nil, &block); end
 
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::ListMeta) }
-        def metadata; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::ListMeta).void)).returns(KubeDSL::DSL::Meta::V1::ListMeta) }
+        def metadata(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def metadata_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/service_spec.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/service_spec.rbi
@@ -68,14 +68,14 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(T::Boolean)).returns(T::Boolean) }
         def publish_not_ready_addresses(val = nil); end
 
-        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.void)).returns(::KubeDSL::KeyValueFields) }
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(::KubeDSL::KeyValueFields).void)).returns(::KubeDSL::KeyValueFields) }
         def selector(&block); end
 
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
         def session_affinity(val = nil); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::SessionAffinityConfig) }
-        def session_affinity_config; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::SessionAffinityConfig).void)).returns(KubeDSL::DSL::V1::SessionAffinityConfig) }
+        def session_affinity_config(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def session_affinity_config_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/service_status.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/service_status.rbi
@@ -26,8 +26,8 @@ module KubeDSL
         }
         def conditions(elem_name = nil, &block); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::LoadBalancerStatus) }
-        def load_balancer; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::LoadBalancerStatus).void)).returns(KubeDSL::DSL::V1::LoadBalancerStatus) }
+        def load_balancer(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def load_balancer_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/session_affinity_config.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/session_affinity_config.rbi
@@ -18,8 +18,8 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { returns(Symbol) }
         def kind_sym; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::ClientIPConfig) }
-        def client_ip; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ClientIPConfig).void)).returns(KubeDSL::DSL::V1::ClientIPConfig) }
+        def client_ip(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def client_ip_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/storage_os_persistent_volume_source.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/storage_os_persistent_volume_source.rbi
@@ -24,8 +24,8 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(T::Boolean)).returns(T::Boolean) }
         def read_only(val = nil); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::ObjectReference) }
-        def secret_ref; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ObjectReference).void)).returns(KubeDSL::DSL::V1::ObjectReference) }
+        def secret_ref(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def secret_ref_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/storage_os_volume_source.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/storage_os_volume_source.rbi
@@ -24,8 +24,8 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(T::Boolean)).returns(T::Boolean) }
         def read_only(val = nil); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::LocalObjectReference) }
-        def secret_ref; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::LocalObjectReference).void)).returns(KubeDSL::DSL::V1::LocalObjectReference) }
+        def secret_ref(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def secret_ref_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/topology_spread_constraint.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/topology_spread_constraint.rbi
@@ -18,8 +18,8 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { returns(Symbol) }
         def kind_sym; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
-        def label_selector; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::Meta::V1::LabelSelector).void)).returns(KubeDSL::DSL::Meta::V1::LabelSelector) }
+        def label_selector(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def label_selector_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/volume.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/volume.rbi
@@ -18,110 +18,110 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { returns(Symbol) }
         def kind_sym; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::AWSElasticBlockStoreVolumeSource) }
-        def aws_elastic_block_store; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::AWSElasticBlockStoreVolumeSource).void)).returns(KubeDSL::DSL::V1::AWSElasticBlockStoreVolumeSource) }
+        def aws_elastic_block_store(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def aws_elastic_block_store_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::AzureDiskVolumeSource) }
-        def azure_disk; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::AzureDiskVolumeSource).void)).returns(KubeDSL::DSL::V1::AzureDiskVolumeSource) }
+        def azure_disk(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def azure_disk_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::AzureFileVolumeSource) }
-        def azure_file; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::AzureFileVolumeSource).void)).returns(KubeDSL::DSL::V1::AzureFileVolumeSource) }
+        def azure_file(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def azure_file_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::CephFSVolumeSource) }
-        def cephfs; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::CephFSVolumeSource).void)).returns(KubeDSL::DSL::V1::CephFSVolumeSource) }
+        def cephfs(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def cephfs_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::CinderVolumeSource) }
-        def cinder; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::CinderVolumeSource).void)).returns(KubeDSL::DSL::V1::CinderVolumeSource) }
+        def cinder(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def cinder_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::ConfigMapVolumeSource) }
-        def config_map; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ConfigMapVolumeSource).void)).returns(KubeDSL::DSL::V1::ConfigMapVolumeSource) }
+        def config_map(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def config_map_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::CSIVolumeSource) }
-        def csi; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::CSIVolumeSource).void)).returns(KubeDSL::DSL::V1::CSIVolumeSource) }
+        def csi(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def csi_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::DownwardAPIVolumeSource) }
-        def downward_api; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::DownwardAPIVolumeSource).void)).returns(KubeDSL::DSL::V1::DownwardAPIVolumeSource) }
+        def downward_api(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def downward_api_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::EmptyDirVolumeSource) }
-        def empty_dir; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::EmptyDirVolumeSource).void)).returns(KubeDSL::DSL::V1::EmptyDirVolumeSource) }
+        def empty_dir(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def empty_dir_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::EphemeralVolumeSource) }
-        def ephemeral; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::EphemeralVolumeSource).void)).returns(KubeDSL::DSL::V1::EphemeralVolumeSource) }
+        def ephemeral(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def ephemeral_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::FCVolumeSource) }
-        def fc; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::FCVolumeSource).void)).returns(KubeDSL::DSL::V1::FCVolumeSource) }
+        def fc(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def fc_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::FlexVolumeSource) }
-        def flex_volume; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::FlexVolumeSource).void)).returns(KubeDSL::DSL::V1::FlexVolumeSource) }
+        def flex_volume(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def flex_volume_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::FlockerVolumeSource) }
-        def flocker; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::FlockerVolumeSource).void)).returns(KubeDSL::DSL::V1::FlockerVolumeSource) }
+        def flocker(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def flocker_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::GCEPersistentDiskVolumeSource) }
-        def gce_persistent_disk; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::GCEPersistentDiskVolumeSource).void)).returns(KubeDSL::DSL::V1::GCEPersistentDiskVolumeSource) }
+        def gce_persistent_disk(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def gce_persistent_disk_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::GitRepoVolumeSource) }
-        def git_repo; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::GitRepoVolumeSource).void)).returns(KubeDSL::DSL::V1::GitRepoVolumeSource) }
+        def git_repo(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def git_repo_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::GlusterfsVolumeSource) }
-        def glusterfs; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::GlusterfsVolumeSource).void)).returns(KubeDSL::DSL::V1::GlusterfsVolumeSource) }
+        def glusterfs(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def glusterfs_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::HostPathVolumeSource) }
-        def host_path; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::HostPathVolumeSource).void)).returns(KubeDSL::DSL::V1::HostPathVolumeSource) }
+        def host_path(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def host_path_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::ISCSIVolumeSource) }
-        def iscsi; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ISCSIVolumeSource).void)).returns(KubeDSL::DSL::V1::ISCSIVolumeSource) }
+        def iscsi(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def iscsi_present?; end
@@ -129,68 +129,68 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { params(val: T.nilable(String)).returns(String) }
         def name(val = nil); end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::NFSVolumeSource) }
-        def nfs; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::NFSVolumeSource).void)).returns(KubeDSL::DSL::V1::NFSVolumeSource) }
+        def nfs(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def nfs_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::PersistentVolumeClaimVolumeSource) }
-        def persistent_volume_claim; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PersistentVolumeClaimVolumeSource).void)).returns(KubeDSL::DSL::V1::PersistentVolumeClaimVolumeSource) }
+        def persistent_volume_claim(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def persistent_volume_claim_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::PhotonPersistentDiskVolumeSource) }
-        def photon_persistent_disk; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PhotonPersistentDiskVolumeSource).void)).returns(KubeDSL::DSL::V1::PhotonPersistentDiskVolumeSource) }
+        def photon_persistent_disk(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def photon_persistent_disk_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::PortworxVolumeSource) }
-        def portworx_volume; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PortworxVolumeSource).void)).returns(KubeDSL::DSL::V1::PortworxVolumeSource) }
+        def portworx_volume(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def portworx_volume_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::ProjectedVolumeSource) }
-        def projected; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ProjectedVolumeSource).void)).returns(KubeDSL::DSL::V1::ProjectedVolumeSource) }
+        def projected(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def projected_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::QuobyteVolumeSource) }
-        def quobyte; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::QuobyteVolumeSource).void)).returns(KubeDSL::DSL::V1::QuobyteVolumeSource) }
+        def quobyte(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def quobyte_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::RBDVolumeSource) }
-        def rbd; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::RBDVolumeSource).void)).returns(KubeDSL::DSL::V1::RBDVolumeSource) }
+        def rbd(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def rbd_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::ScaleIOVolumeSource) }
-        def scale_io; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ScaleIOVolumeSource).void)).returns(KubeDSL::DSL::V1::ScaleIOVolumeSource) }
+        def scale_io(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def scale_io_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::SecretVolumeSource) }
-        def secret; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::SecretVolumeSource).void)).returns(KubeDSL::DSL::V1::SecretVolumeSource) }
+        def secret(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def secret_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::StorageOSVolumeSource) }
-        def storageos; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::StorageOSVolumeSource).void)).returns(KubeDSL::DSL::V1::StorageOSVolumeSource) }
+        def storageos(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def storageos_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::VsphereVirtualDiskVolumeSource) }
-        def vsphere_volume; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::VsphereVirtualDiskVolumeSource).void)).returns(KubeDSL::DSL::V1::VsphereVirtualDiskVolumeSource) }
+        def vsphere_volume(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def vsphere_volume_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/volume_node_affinity.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/volume_node_affinity.rbi
@@ -18,8 +18,8 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { returns(Symbol) }
         def kind_sym; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::NodeSelector) }
-        def required; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::NodeSelector).void)).returns(KubeDSL::DSL::V1::NodeSelector) }
+        def required(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def required_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/volume_projection.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/volume_projection.rbi
@@ -18,26 +18,26 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { returns(Symbol) }
         def kind_sym; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::ConfigMapProjection) }
-        def config_map; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ConfigMapProjection).void)).returns(KubeDSL::DSL::V1::ConfigMapProjection) }
+        def config_map(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def config_map_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::DownwardAPIProjection) }
-        def downward_api; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::DownwardAPIProjection).void)).returns(KubeDSL::DSL::V1::DownwardAPIProjection) }
+        def downward_api(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def downward_api_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::SecretProjection) }
-        def secret; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::SecretProjection).void)).returns(KubeDSL::DSL::V1::SecretProjection) }
+        def secret(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def secret_present?; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::ServiceAccountTokenProjection) }
-        def service_account_token; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::ServiceAccountTokenProjection).void)).returns(KubeDSL::DSL::V1::ServiceAccountTokenProjection) }
+        def service_account_token(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def service_account_token_present?; end

--- a/sorbet/rbi/kube-dsl/dsl/v1/weighted_pod_affinity_term.rbi
+++ b/sorbet/rbi/kube-dsl/dsl/v1/weighted_pod_affinity_term.rbi
@@ -18,8 +18,8 @@ module KubeDSL
         T::Sig::WithoutRuntime.sig { returns(Symbol) }
         def kind_sym; end
 
-        T::Sig::WithoutRuntime.sig { returns(KubeDSL::DSL::V1::PodAffinityTerm) }
-        def pod_affinity_term; end
+        T::Sig::WithoutRuntime.sig { params(block: T.nilable(T.proc.bind(KubeDSL::DSL::V1::PodAffinityTerm).void)).returns(KubeDSL::DSL::V1::PodAffinityTerm) }
+        def pod_affinity_term(&block); end
         
         T::Sig::WithoutRuntime.sig { returns(T::Boolean) }
         def pod_affinity_term_present?; end

--- a/sorbet/rbi/kube-dsl/entrypoint.rbi
+++ b/sorbet/rbi/kube-dsl/entrypoint.rbi
@@ -2,1258 +2,1258 @@
 
 module KubeDSL
   module Entrypoint
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Admissionregistration::V1::MutatingWebhook) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Admissionregistration::V1::MutatingWebhook).void).returns(::KubeDSL::DSL::Admissionregistration::V1::MutatingWebhook) }
     def mutating_webhook(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Admissionregistration::V1::MutatingWebhookConfiguration) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Admissionregistration::V1::MutatingWebhookConfiguration).void).returns(::KubeDSL::DSL::Admissionregistration::V1::MutatingWebhookConfiguration) }
     def mutating_webhook_configuration(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Admissionregistration::V1::MutatingWebhookConfigurationList) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Admissionregistration::V1::MutatingWebhookConfigurationList).void).returns(::KubeDSL::DSL::Admissionregistration::V1::MutatingWebhookConfigurationList) }
     def mutating_webhook_configuration_list(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Admissionregistration::V1::RuleWithOperations) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Admissionregistration::V1::RuleWithOperations).void).returns(::KubeDSL::DSL::Admissionregistration::V1::RuleWithOperations) }
     def rule_with_operations(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Admissionregistration::V1::ServiceReference) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Admissionregistration::V1::ServiceReference).void).returns(::KubeDSL::DSL::Admissionregistration::V1::ServiceReference) }
     def admissionregistration_v1_service_reference(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Admissionregistration::V1::ValidatingWebhook) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Admissionregistration::V1::ValidatingWebhook).void).returns(::KubeDSL::DSL::Admissionregistration::V1::ValidatingWebhook) }
     def validating_webhook(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Admissionregistration::V1::ValidatingWebhookConfiguration) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Admissionregistration::V1::ValidatingWebhookConfiguration).void).returns(::KubeDSL::DSL::Admissionregistration::V1::ValidatingWebhookConfiguration) }
     def validating_webhook_configuration(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Admissionregistration::V1::ValidatingWebhookConfigurationList) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Admissionregistration::V1::ValidatingWebhookConfigurationList).void).returns(::KubeDSL::DSL::Admissionregistration::V1::ValidatingWebhookConfigurationList) }
     def validating_webhook_configuration_list(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Admissionregistration::V1::WebhookClientConfig) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Admissionregistration::V1::WebhookClientConfig).void).returns(::KubeDSL::DSL::Admissionregistration::V1::WebhookClientConfig) }
     def admissionregistration_v1_webhook_client_config(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::ControllerRevision) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::ControllerRevision).void).returns(::KubeDSL::DSL::Apps::V1::ControllerRevision) }
     def controller_revision(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::ControllerRevisionList) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::ControllerRevisionList).void).returns(::KubeDSL::DSL::Apps::V1::ControllerRevisionList) }
     def controller_revision_list(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::DaemonSet) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::DaemonSet).void).returns(::KubeDSL::DSL::Apps::V1::DaemonSet) }
     def daemon_set(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::DaemonSetCondition) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::DaemonSetCondition).void).returns(::KubeDSL::DSL::Apps::V1::DaemonSetCondition) }
     def daemon_set_condition(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::DaemonSetList) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::DaemonSetList).void).returns(::KubeDSL::DSL::Apps::V1::DaemonSetList) }
     def daemon_set_list(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::DaemonSetSpec) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::DaemonSetSpec).void).returns(::KubeDSL::DSL::Apps::V1::DaemonSetSpec) }
     def daemon_set_spec(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::DaemonSetStatus) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::DaemonSetStatus).void).returns(::KubeDSL::DSL::Apps::V1::DaemonSetStatus) }
     def daemon_set_status(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::DaemonSetUpdateStrategy) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::DaemonSetUpdateStrategy).void).returns(::KubeDSL::DSL::Apps::V1::DaemonSetUpdateStrategy) }
     def daemon_set_update_strategy(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::Deployment) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::Deployment).void).returns(::KubeDSL::DSL::Apps::V1::Deployment) }
     def deployment(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::DeploymentCondition) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::DeploymentCondition).void).returns(::KubeDSL::DSL::Apps::V1::DeploymentCondition) }
     def deployment_condition(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::DeploymentList) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::DeploymentList).void).returns(::KubeDSL::DSL::Apps::V1::DeploymentList) }
     def deployment_list(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::DeploymentSpec) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::DeploymentSpec).void).returns(::KubeDSL::DSL::Apps::V1::DeploymentSpec) }
     def deployment_spec(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::DeploymentStatus) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::DeploymentStatus).void).returns(::KubeDSL::DSL::Apps::V1::DeploymentStatus) }
     def deployment_status(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::DeploymentStrategy) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::DeploymentStrategy).void).returns(::KubeDSL::DSL::Apps::V1::DeploymentStrategy) }
     def deployment_strategy(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::ReplicaSet) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::ReplicaSet).void).returns(::KubeDSL::DSL::Apps::V1::ReplicaSet) }
     def replica_set(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::ReplicaSetCondition) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::ReplicaSetCondition).void).returns(::KubeDSL::DSL::Apps::V1::ReplicaSetCondition) }
     def replica_set_condition(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::ReplicaSetList) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::ReplicaSetList).void).returns(::KubeDSL::DSL::Apps::V1::ReplicaSetList) }
     def replica_set_list(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::ReplicaSetSpec) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::ReplicaSetSpec).void).returns(::KubeDSL::DSL::Apps::V1::ReplicaSetSpec) }
     def replica_set_spec(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::ReplicaSetStatus) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::ReplicaSetStatus).void).returns(::KubeDSL::DSL::Apps::V1::ReplicaSetStatus) }
     def replica_set_status(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::RollingUpdateDaemonSet) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::RollingUpdateDaemonSet).void).returns(::KubeDSL::DSL::Apps::V1::RollingUpdateDaemonSet) }
     def rolling_update_daemon_set(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::RollingUpdateDeployment) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::RollingUpdateDeployment).void).returns(::KubeDSL::DSL::Apps::V1::RollingUpdateDeployment) }
     def rolling_update_deployment(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::RollingUpdateStatefulSetStrategy) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::RollingUpdateStatefulSetStrategy).void).returns(::KubeDSL::DSL::Apps::V1::RollingUpdateStatefulSetStrategy) }
     def rolling_update_stateful_set_strategy(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::StatefulSet) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::StatefulSet).void).returns(::KubeDSL::DSL::Apps::V1::StatefulSet) }
     def stateful_set(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::StatefulSetCondition) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::StatefulSetCondition).void).returns(::KubeDSL::DSL::Apps::V1::StatefulSetCondition) }
     def stateful_set_condition(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::StatefulSetList) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::StatefulSetList).void).returns(::KubeDSL::DSL::Apps::V1::StatefulSetList) }
     def stateful_set_list(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::StatefulSetPersistentVolumeClaimRetentionPolicy) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::StatefulSetPersistentVolumeClaimRetentionPolicy).void).returns(::KubeDSL::DSL::Apps::V1::StatefulSetPersistentVolumeClaimRetentionPolicy) }
     def stateful_set_persistent_volume_claim_retention_policy(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::StatefulSetSpec) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::StatefulSetSpec).void).returns(::KubeDSL::DSL::Apps::V1::StatefulSetSpec) }
     def stateful_set_spec(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::StatefulSetStatus) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::StatefulSetStatus).void).returns(::KubeDSL::DSL::Apps::V1::StatefulSetStatus) }
     def stateful_set_status(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apps::V1::StatefulSetUpdateStrategy) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Apps::V1::StatefulSetUpdateStrategy).void).returns(::KubeDSL::DSL::Apps::V1::StatefulSetUpdateStrategy) }
     def stateful_set_update_strategy(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Authentication::V1::BoundObjectReference) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Authentication::V1::BoundObjectReference).void).returns(::KubeDSL::DSL::Authentication::V1::BoundObjectReference) }
     def bound_object_reference(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Authentication::V1::TokenRequest) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Authentication::V1::TokenRequest).void).returns(::KubeDSL::DSL::Authentication::V1::TokenRequest) }
     def authentication_v1_token_request(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Authentication::V1::TokenRequestSpec) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Authentication::V1::TokenRequestSpec).void).returns(::KubeDSL::DSL::Authentication::V1::TokenRequestSpec) }
     def token_request_spec(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Authentication::V1::TokenRequestStatus) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Authentication::V1::TokenRequestStatus).void).returns(::KubeDSL::DSL::Authentication::V1::TokenRequestStatus) }
     def token_request_status(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Authentication::V1::TokenReview) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Authentication::V1::TokenReview).void).returns(::KubeDSL::DSL::Authentication::V1::TokenReview) }
     def token_review(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Authentication::V1::TokenReviewSpec) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Authentication::V1::TokenReviewSpec).void).returns(::KubeDSL::DSL::Authentication::V1::TokenReviewSpec) }
     def token_review_spec(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Authentication::V1::TokenReviewStatus) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Authentication::V1::TokenReviewStatus).void).returns(::KubeDSL::DSL::Authentication::V1::TokenReviewStatus) }
     def token_review_status(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Authentication::V1::UserInfo) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Authentication::V1::UserInfo).void).returns(::KubeDSL::DSL::Authentication::V1::UserInfo) }
     def user_info(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Authorization::V1::LocalSubjectAccessReview) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Authorization::V1::LocalSubjectAccessReview).void).returns(::KubeDSL::DSL::Authorization::V1::LocalSubjectAccessReview) }
     def local_subject_access_review(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Authorization::V1::NonResourceAttributes) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Authorization::V1::NonResourceAttributes).void).returns(::KubeDSL::DSL::Authorization::V1::NonResourceAttributes) }
     def non_resource_attributes(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Authorization::V1::NonResourceRule) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Authorization::V1::NonResourceRule).void).returns(::KubeDSL::DSL::Authorization::V1::NonResourceRule) }
     def non_resource_rule(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Authorization::V1::ResourceAttributes) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Authorization::V1::ResourceAttributes).void).returns(::KubeDSL::DSL::Authorization::V1::ResourceAttributes) }
     def resource_attributes(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Authorization::V1::ResourceRule) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Authorization::V1::ResourceRule).void).returns(::KubeDSL::DSL::Authorization::V1::ResourceRule) }
     def resource_rule(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Authorization::V1::SelfSubjectAccessReview) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Authorization::V1::SelfSubjectAccessReview).void).returns(::KubeDSL::DSL::Authorization::V1::SelfSubjectAccessReview) }
     def self_subject_access_review(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Authorization::V1::SelfSubjectAccessReviewSpec) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Authorization::V1::SelfSubjectAccessReviewSpec).void).returns(::KubeDSL::DSL::Authorization::V1::SelfSubjectAccessReviewSpec) }
     def self_subject_access_review_spec(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Authorization::V1::SelfSubjectRulesReview) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Authorization::V1::SelfSubjectRulesReview).void).returns(::KubeDSL::DSL::Authorization::V1::SelfSubjectRulesReview) }
     def self_subject_rules_review(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Authorization::V1::SelfSubjectRulesReviewSpec) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Authorization::V1::SelfSubjectRulesReviewSpec).void).returns(::KubeDSL::DSL::Authorization::V1::SelfSubjectRulesReviewSpec) }
     def self_subject_rules_review_spec(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Authorization::V1::SubjectAccessReview) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Authorization::V1::SubjectAccessReview).void).returns(::KubeDSL::DSL::Authorization::V1::SubjectAccessReview) }
     def subject_access_review(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Authorization::V1::SubjectAccessReviewSpec) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Authorization::V1::SubjectAccessReviewSpec).void).returns(::KubeDSL::DSL::Authorization::V1::SubjectAccessReviewSpec) }
     def subject_access_review_spec(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Authorization::V1::SubjectAccessReviewStatus) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Authorization::V1::SubjectAccessReviewStatus).void).returns(::KubeDSL::DSL::Authorization::V1::SubjectAccessReviewStatus) }
     def subject_access_review_status(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Authorization::V1::SubjectRulesReviewStatus) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Authorization::V1::SubjectRulesReviewStatus).void).returns(::KubeDSL::DSL::Authorization::V1::SubjectRulesReviewStatus) }
     def subject_rules_review_status(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V1::CrossVersionObjectReference) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V1::CrossVersionObjectReference).void).returns(::KubeDSL::DSL::Autoscaling::V1::CrossVersionObjectReference) }
     def autoscaling_v1_cross_version_object_reference(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V1::HorizontalPodAutoscaler) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V1::HorizontalPodAutoscaler).void).returns(::KubeDSL::DSL::Autoscaling::V1::HorizontalPodAutoscaler) }
     def autoscaling_v1_horizontal_pod_autoscaler(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V1::HorizontalPodAutoscalerList) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V1::HorizontalPodAutoscalerList).void).returns(::KubeDSL::DSL::Autoscaling::V1::HorizontalPodAutoscalerList) }
     def autoscaling_v1_horizontal_pod_autoscaler_list(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V1::HorizontalPodAutoscalerSpec) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V1::HorizontalPodAutoscalerSpec).void).returns(::KubeDSL::DSL::Autoscaling::V1::HorizontalPodAutoscalerSpec) }
     def autoscaling_v1_horizontal_pod_autoscaler_spec(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V1::HorizontalPodAutoscalerStatus) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V1::HorizontalPodAutoscalerStatus).void).returns(::KubeDSL::DSL::Autoscaling::V1::HorizontalPodAutoscalerStatus) }
     def autoscaling_v1_horizontal_pod_autoscaler_status(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V1::Scale) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V1::Scale).void).returns(::KubeDSL::DSL::Autoscaling::V1::Scale) }
     def scale(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V1::ScaleSpec) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V1::ScaleSpec).void).returns(::KubeDSL::DSL::Autoscaling::V1::ScaleSpec) }
     def scale_spec(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V1::ScaleStatus) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V1::ScaleStatus).void).returns(::KubeDSL::DSL::Autoscaling::V1::ScaleStatus) }
     def scale_status(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V2::ContainerResourceMetricSource) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V2::ContainerResourceMetricSource).void).returns(::KubeDSL::DSL::Autoscaling::V2::ContainerResourceMetricSource) }
     def container_resource_metric_source(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V2::ContainerResourceMetricStatus) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V2::ContainerResourceMetricStatus).void).returns(::KubeDSL::DSL::Autoscaling::V2::ContainerResourceMetricStatus) }
     def container_resource_metric_status(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V2::CrossVersionObjectReference) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V2::CrossVersionObjectReference).void).returns(::KubeDSL::DSL::Autoscaling::V2::CrossVersionObjectReference) }
     def autoscaling_v2_cross_version_object_reference(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V2::ExternalMetricSource) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V2::ExternalMetricSource).void).returns(::KubeDSL::DSL::Autoscaling::V2::ExternalMetricSource) }
     def external_metric_source(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V2::ExternalMetricStatus) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V2::ExternalMetricStatus).void).returns(::KubeDSL::DSL::Autoscaling::V2::ExternalMetricStatus) }
     def external_metric_status(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V2::HPAScalingPolicy) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V2::HPAScalingPolicy).void).returns(::KubeDSL::DSL::Autoscaling::V2::HPAScalingPolicy) }
     def hpa_scaling_policy(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V2::HPAScalingRules) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V2::HPAScalingRules).void).returns(::KubeDSL::DSL::Autoscaling::V2::HPAScalingRules) }
     def hpa_scaling_rules(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscaler) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscaler).void).returns(::KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscaler) }
     def autoscaling_v2_horizontal_pod_autoscaler(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscalerBehavior) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscalerBehavior).void).returns(::KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscalerBehavior) }
     def horizontal_pod_autoscaler_behavior(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscalerCondition) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscalerCondition).void).returns(::KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscalerCondition) }
     def horizontal_pod_autoscaler_condition(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscalerList) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscalerList).void).returns(::KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscalerList) }
     def autoscaling_v2_horizontal_pod_autoscaler_list(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscalerSpec) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscalerSpec).void).returns(::KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscalerSpec) }
     def autoscaling_v2_horizontal_pod_autoscaler_spec(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscalerStatus) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscalerStatus).void).returns(::KubeDSL::DSL::Autoscaling::V2::HorizontalPodAutoscalerStatus) }
     def autoscaling_v2_horizontal_pod_autoscaler_status(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V2::MetricIdentifier) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V2::MetricIdentifier).void).returns(::KubeDSL::DSL::Autoscaling::V2::MetricIdentifier) }
     def metric_identifier(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V2::MetricSpec) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V2::MetricSpec).void).returns(::KubeDSL::DSL::Autoscaling::V2::MetricSpec) }
     def metric_spec(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V2::MetricStatus) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V2::MetricStatus).void).returns(::KubeDSL::DSL::Autoscaling::V2::MetricStatus) }
     def metric_status(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V2::MetricTarget) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V2::MetricTarget).void).returns(::KubeDSL::DSL::Autoscaling::V2::MetricTarget) }
     def metric_target(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V2::MetricValueStatus) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V2::MetricValueStatus).void).returns(::KubeDSL::DSL::Autoscaling::V2::MetricValueStatus) }
     def metric_value_status(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V2::ObjectMetricSource) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V2::ObjectMetricSource).void).returns(::KubeDSL::DSL::Autoscaling::V2::ObjectMetricSource) }
     def object_metric_source(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V2::ObjectMetricStatus) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V2::ObjectMetricStatus).void).returns(::KubeDSL::DSL::Autoscaling::V2::ObjectMetricStatus) }
     def object_metric_status(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V2::PodsMetricSource) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V2::PodsMetricSource).void).returns(::KubeDSL::DSL::Autoscaling::V2::PodsMetricSource) }
     def pods_metric_source(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V2::PodsMetricStatus) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V2::PodsMetricStatus).void).returns(::KubeDSL::DSL::Autoscaling::V2::PodsMetricStatus) }
     def pods_metric_status(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V2::ResourceMetricSource) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V2::ResourceMetricSource).void).returns(::KubeDSL::DSL::Autoscaling::V2::ResourceMetricSource) }
     def resource_metric_source(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Autoscaling::V2::ResourceMetricStatus) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Autoscaling::V2::ResourceMetricStatus).void).returns(::KubeDSL::DSL::Autoscaling::V2::ResourceMetricStatus) }
     def resource_metric_status(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Batch::V1::CronJob) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Batch::V1::CronJob).void).returns(::KubeDSL::DSL::Batch::V1::CronJob) }
     def cron_job(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Batch::V1::CronJobList) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Batch::V1::CronJobList).void).returns(::KubeDSL::DSL::Batch::V1::CronJobList) }
     def cron_job_list(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Batch::V1::CronJobSpec) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Batch::V1::CronJobSpec).void).returns(::KubeDSL::DSL::Batch::V1::CronJobSpec) }
     def cron_job_spec(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Batch::V1::CronJobStatus) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Batch::V1::CronJobStatus).void).returns(::KubeDSL::DSL::Batch::V1::CronJobStatus) }
     def cron_job_status(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Batch::V1::Job) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Batch::V1::Job).void).returns(::KubeDSL::DSL::Batch::V1::Job) }
     def job(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Batch::V1::JobCondition) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Batch::V1::JobCondition).void).returns(::KubeDSL::DSL::Batch::V1::JobCondition) }
     def job_condition(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Batch::V1::JobList) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Batch::V1::JobList).void).returns(::KubeDSL::DSL::Batch::V1::JobList) }
     def job_list(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Batch::V1::JobSpec) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Batch::V1::JobSpec).void).returns(::KubeDSL::DSL::Batch::V1::JobSpec) }
     def job_spec(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Batch::V1::JobStatus) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Batch::V1::JobStatus).void).returns(::KubeDSL::DSL::Batch::V1::JobStatus) }
     def job_status(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Batch::V1::JobTemplateSpec) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Batch::V1::JobTemplateSpec).void).returns(::KubeDSL::DSL::Batch::V1::JobTemplateSpec) }
     def job_template_spec(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Batch::V1::UncountedTerminatedPods) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Batch::V1::UncountedTerminatedPods).void).returns(::KubeDSL::DSL::Batch::V1::UncountedTerminatedPods) }
     def uncounted_terminated_pods(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Certificates::V1::CertificateSigningRequest) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Certificates::V1::CertificateSigningRequest).void).returns(::KubeDSL::DSL::Certificates::V1::CertificateSigningRequest) }
     def certificate_signing_request(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Certificates::V1::CertificateSigningRequestCondition) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Certificates::V1::CertificateSigningRequestCondition).void).returns(::KubeDSL::DSL::Certificates::V1::CertificateSigningRequestCondition) }
     def certificate_signing_request_condition(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Certificates::V1::CertificateSigningRequestList) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Certificates::V1::CertificateSigningRequestList).void).returns(::KubeDSL::DSL::Certificates::V1::CertificateSigningRequestList) }
     def certificate_signing_request_list(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Certificates::V1::CertificateSigningRequestSpec) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Certificates::V1::CertificateSigningRequestSpec).void).returns(::KubeDSL::DSL::Certificates::V1::CertificateSigningRequestSpec) }
     def certificate_signing_request_spec(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Certificates::V1::CertificateSigningRequestStatus) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Certificates::V1::CertificateSigningRequestStatus).void).returns(::KubeDSL::DSL::Certificates::V1::CertificateSigningRequestStatus) }
     def certificate_signing_request_status(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Coordination::V1::Lease) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Coordination::V1::Lease).void).returns(::KubeDSL::DSL::Coordination::V1::Lease) }
     def lease(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Coordination::V1::LeaseList) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Coordination::V1::LeaseList).void).returns(::KubeDSL::DSL::Coordination::V1::LeaseList) }
     def lease_list(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Coordination::V1::LeaseSpec) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Coordination::V1::LeaseSpec).void).returns(::KubeDSL::DSL::Coordination::V1::LeaseSpec) }
     def lease_spec(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::AWSElasticBlockStoreVolumeSource) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::AWSElasticBlockStoreVolumeSource).void).returns(::KubeDSL::DSL::V1::AWSElasticBlockStoreVolumeSource) }
     def aws_elastic_block_store_volume_source(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::Affinity) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::Affinity).void).returns(::KubeDSL::DSL::V1::Affinity) }
     def affinity(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::AttachedVolume) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::AttachedVolume).void).returns(::KubeDSL::DSL::V1::AttachedVolume) }
     def attached_volume(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::AzureDiskVolumeSource) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::AzureDiskVolumeSource).void).returns(::KubeDSL::DSL::V1::AzureDiskVolumeSource) }
     def azure_disk_volume_source(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::AzureFilePersistentVolumeSource) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::AzureFilePersistentVolumeSource).void).returns(::KubeDSL::DSL::V1::AzureFilePersistentVolumeSource) }
     def azure_file_persistent_volume_source(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::AzureFileVolumeSource) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::AzureFileVolumeSource).void).returns(::KubeDSL::DSL::V1::AzureFileVolumeSource) }
     def azure_file_volume_source(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::Binding) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::Binding).void).returns(::KubeDSL::DSL::V1::Binding) }
     def binding(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::CSIPersistentVolumeSource) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::CSIPersistentVolumeSource).void).returns(::KubeDSL::DSL::V1::CSIPersistentVolumeSource) }
     def csi_persistent_volume_source(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::CSIVolumeSource) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::CSIVolumeSource).void).returns(::KubeDSL::DSL::V1::CSIVolumeSource) }
     def csi_volume_source(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::Capabilities) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::Capabilities).void).returns(::KubeDSL::DSL::V1::Capabilities) }
     def capabilities(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::CephFSPersistentVolumeSource) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::CephFSPersistentVolumeSource).void).returns(::KubeDSL::DSL::V1::CephFSPersistentVolumeSource) }
     def ceph_fs_persistent_volume_source(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::CephFSVolumeSource) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::CephFSVolumeSource).void).returns(::KubeDSL::DSL::V1::CephFSVolumeSource) }
     def ceph_fs_volume_source(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::CinderPersistentVolumeSource) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::CinderPersistentVolumeSource).void).returns(::KubeDSL::DSL::V1::CinderPersistentVolumeSource) }
     def cinder_persistent_volume_source(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::CinderVolumeSource) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::CinderVolumeSource).void).returns(::KubeDSL::DSL::V1::CinderVolumeSource) }
     def cinder_volume_source(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ClientIPConfig) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ClientIPConfig).void).returns(::KubeDSL::DSL::V1::ClientIPConfig) }
     def client_ip_config(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ComponentCondition) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ComponentCondition).void).returns(::KubeDSL::DSL::V1::ComponentCondition) }
     def component_condition(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ComponentStatus) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ComponentStatus).void).returns(::KubeDSL::DSL::V1::ComponentStatus) }
     def component_status(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ComponentStatusList) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ComponentStatusList).void).returns(::KubeDSL::DSL::V1::ComponentStatusList) }
     def component_status_list(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ConfigMap) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ConfigMap).void).returns(::KubeDSL::DSL::V1::ConfigMap) }
     def config_map(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ConfigMapEnvSource) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ConfigMapEnvSource).void).returns(::KubeDSL::DSL::V1::ConfigMapEnvSource) }
     def config_map_env_source(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ConfigMapKeySelector) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ConfigMapKeySelector).void).returns(::KubeDSL::DSL::V1::ConfigMapKeySelector) }
     def config_map_key_selector(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ConfigMapList) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ConfigMapList).void).returns(::KubeDSL::DSL::V1::ConfigMapList) }
     def config_map_list(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ConfigMapNodeConfigSource) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ConfigMapNodeConfigSource).void).returns(::KubeDSL::DSL::V1::ConfigMapNodeConfigSource) }
     def config_map_node_config_source(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ConfigMapProjection) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ConfigMapProjection).void).returns(::KubeDSL::DSL::V1::ConfigMapProjection) }
     def config_map_projection(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ConfigMapVolumeSource) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ConfigMapVolumeSource).void).returns(::KubeDSL::DSL::V1::ConfigMapVolumeSource) }
     def config_map_volume_source(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::Container) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::Container).void).returns(::KubeDSL::DSL::V1::Container) }
     def container(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ContainerImage) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ContainerImage).void).returns(::KubeDSL::DSL::V1::ContainerImage) }
     def container_image(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ContainerPort) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ContainerPort).void).returns(::KubeDSL::DSL::V1::ContainerPort) }
     def container_port(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ContainerState) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ContainerState).void).returns(::KubeDSL::DSL::V1::ContainerState) }
     def container_state(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ContainerStateRunning) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ContainerStateRunning).void).returns(::KubeDSL::DSL::V1::ContainerStateRunning) }
     def container_state_running(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ContainerStateTerminated) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ContainerStateTerminated).void).returns(::KubeDSL::DSL::V1::ContainerStateTerminated) }
     def container_state_terminated(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ContainerStateWaiting) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ContainerStateWaiting).void).returns(::KubeDSL::DSL::V1::ContainerStateWaiting) }
     def container_state_waiting(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ContainerStatus) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ContainerStatus).void).returns(::KubeDSL::DSL::V1::ContainerStatus) }
     def container_status(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::DaemonEndpoint) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::DaemonEndpoint).void).returns(::KubeDSL::DSL::V1::DaemonEndpoint) }
     def daemon_endpoint(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::DownwardAPIProjection) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::DownwardAPIProjection).void).returns(::KubeDSL::DSL::V1::DownwardAPIProjection) }
     def downward_api_projection(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::DownwardAPIVolumeFile) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::DownwardAPIVolumeFile).void).returns(::KubeDSL::DSL::V1::DownwardAPIVolumeFile) }
     def downward_api_volume_file(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::DownwardAPIVolumeSource) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::DownwardAPIVolumeSource).void).returns(::KubeDSL::DSL::V1::DownwardAPIVolumeSource) }
     def downward_api_volume_source(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::EmptyDirVolumeSource) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::EmptyDirVolumeSource).void).returns(::KubeDSL::DSL::V1::EmptyDirVolumeSource) }
     def empty_dir_volume_source(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::EndpointAddress) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::EndpointAddress).void).returns(::KubeDSL::DSL::V1::EndpointAddress) }
     def endpoint_address(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::EndpointPort) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::EndpointPort).void).returns(::KubeDSL::DSL::V1::EndpointPort) }
     def v1_endpoint_port(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::EndpointSubset) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::EndpointSubset).void).returns(::KubeDSL::DSL::V1::EndpointSubset) }
     def endpoint_subset(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::Endpoints) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::Endpoints).void).returns(::KubeDSL::DSL::V1::Endpoints) }
     def endpoints(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::EndpointsList) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::EndpointsList).void).returns(::KubeDSL::DSL::V1::EndpointsList) }
     def endpoints_list(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::EnvFromSource) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::EnvFromSource).void).returns(::KubeDSL::DSL::V1::EnvFromSource) }
     def env_from_source(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::EnvVar) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::EnvVar).void).returns(::KubeDSL::DSL::V1::EnvVar) }
     def env_var(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::EnvVarSource) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::EnvVarSource).void).returns(::KubeDSL::DSL::V1::EnvVarSource) }
     def env_var_source(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::EphemeralContainer) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::EphemeralContainer).void).returns(::KubeDSL::DSL::V1::EphemeralContainer) }
     def ephemeral_container(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::EphemeralVolumeSource) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::EphemeralVolumeSource).void).returns(::KubeDSL::DSL::V1::EphemeralVolumeSource) }
     def ephemeral_volume_source(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::Event) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::Event).void).returns(::KubeDSL::DSL::V1::Event) }
     def v1_event(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::EventList) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::EventList).void).returns(::KubeDSL::DSL::V1::EventList) }
     def v1_event_list(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::EventSeries) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::EventSeries).void).returns(::KubeDSL::DSL::V1::EventSeries) }
     def v1_event_series(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::EventSource) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::EventSource).void).returns(::KubeDSL::DSL::V1::EventSource) }
     def event_source(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ExecAction) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ExecAction).void).returns(::KubeDSL::DSL::V1::ExecAction) }
     def exec_action(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::FCVolumeSource) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::FCVolumeSource).void).returns(::KubeDSL::DSL::V1::FCVolumeSource) }
     def fc_volume_source(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::FlexPersistentVolumeSource) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::FlexPersistentVolumeSource).void).returns(::KubeDSL::DSL::V1::FlexPersistentVolumeSource) }
     def flex_persistent_volume_source(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::FlexVolumeSource) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::FlexVolumeSource).void).returns(::KubeDSL::DSL::V1::FlexVolumeSource) }
     def flex_volume_source(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::FlockerVolumeSource) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::FlockerVolumeSource).void).returns(::KubeDSL::DSL::V1::FlockerVolumeSource) }
     def flocker_volume_source(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::GCEPersistentDiskVolumeSource) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::GCEPersistentDiskVolumeSource).void).returns(::KubeDSL::DSL::V1::GCEPersistentDiskVolumeSource) }
     def gce_persistent_disk_volume_source(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::GRPCAction) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::GRPCAction).void).returns(::KubeDSL::DSL::V1::GRPCAction) }
     def grpc_action(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::GitRepoVolumeSource) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::GitRepoVolumeSource).void).returns(::KubeDSL::DSL::V1::GitRepoVolumeSource) }
     def git_repo_volume_source(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::GlusterfsPersistentVolumeSource) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::GlusterfsPersistentVolumeSource).void).returns(::KubeDSL::DSL::V1::GlusterfsPersistentVolumeSource) }
     def glusterfs_persistent_volume_source(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::GlusterfsVolumeSource) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::GlusterfsVolumeSource).void).returns(::KubeDSL::DSL::V1::GlusterfsVolumeSource) }
     def glusterfs_volume_source(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::HTTPGetAction) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::HTTPGetAction).void).returns(::KubeDSL::DSL::V1::HTTPGetAction) }
     def http_get_action(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::HTTPHeader) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::HTTPHeader).void).returns(::KubeDSL::DSL::V1::HTTPHeader) }
     def http_header(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::HostAlias) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::HostAlias).void).returns(::KubeDSL::DSL::V1::HostAlias) }
     def host_alias(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::HostPathVolumeSource) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::HostPathVolumeSource).void).returns(::KubeDSL::DSL::V1::HostPathVolumeSource) }
     def host_path_volume_source(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ISCSIPersistentVolumeSource) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ISCSIPersistentVolumeSource).void).returns(::KubeDSL::DSL::V1::ISCSIPersistentVolumeSource) }
     def iscsi_persistent_volume_source(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ISCSIVolumeSource) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ISCSIVolumeSource).void).returns(::KubeDSL::DSL::V1::ISCSIVolumeSource) }
     def iscsi_volume_source(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::KeyToPath) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::KeyToPath).void).returns(::KubeDSL::DSL::V1::KeyToPath) }
     def key_to_path(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::Lifecycle) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::Lifecycle).void).returns(::KubeDSL::DSL::V1::Lifecycle) }
     def lifecycle(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::LifecycleHandler) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::LifecycleHandler).void).returns(::KubeDSL::DSL::V1::LifecycleHandler) }
     def lifecycle_handler(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::LimitRange) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::LimitRange).void).returns(::KubeDSL::DSL::V1::LimitRange) }
     def limit_range(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::LimitRangeItem) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::LimitRangeItem).void).returns(::KubeDSL::DSL::V1::LimitRangeItem) }
     def limit_range_item(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::LimitRangeList) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::LimitRangeList).void).returns(::KubeDSL::DSL::V1::LimitRangeList) }
     def limit_range_list(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::LimitRangeSpec) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::LimitRangeSpec).void).returns(::KubeDSL::DSL::V1::LimitRangeSpec) }
     def limit_range_spec(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::LoadBalancerIngress) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::LoadBalancerIngress).void).returns(::KubeDSL::DSL::V1::LoadBalancerIngress) }
     def load_balancer_ingress(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::LoadBalancerStatus) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::LoadBalancerStatus).void).returns(::KubeDSL::DSL::V1::LoadBalancerStatus) }
     def load_balancer_status(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::LocalObjectReference) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::LocalObjectReference).void).returns(::KubeDSL::DSL::V1::LocalObjectReference) }
     def local_object_reference(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::LocalVolumeSource) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::LocalVolumeSource).void).returns(::KubeDSL::DSL::V1::LocalVolumeSource) }
     def local_volume_source(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::NFSVolumeSource) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::NFSVolumeSource).void).returns(::KubeDSL::DSL::V1::NFSVolumeSource) }
     def nfs_volume_source(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::Namespace) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::Namespace).void).returns(::KubeDSL::DSL::V1::Namespace) }
     def namespace(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::NamespaceCondition) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::NamespaceCondition).void).returns(::KubeDSL::DSL::V1::NamespaceCondition) }
     def namespace_condition(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::NamespaceList) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::NamespaceList).void).returns(::KubeDSL::DSL::V1::NamespaceList) }
     def namespace_list(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::NamespaceSpec) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::NamespaceSpec).void).returns(::KubeDSL::DSL::V1::NamespaceSpec) }
     def namespace_spec(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::NamespaceStatus) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::NamespaceStatus).void).returns(::KubeDSL::DSL::V1::NamespaceStatus) }
     def namespace_status(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::Node) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::Node).void).returns(::KubeDSL::DSL::V1::Node) }
     def node(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::NodeAddress) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::NodeAddress).void).returns(::KubeDSL::DSL::V1::NodeAddress) }
     def node_address(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::NodeAffinity) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::NodeAffinity).void).returns(::KubeDSL::DSL::V1::NodeAffinity) }
     def node_affinity(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::NodeCondition) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::NodeCondition).void).returns(::KubeDSL::DSL::V1::NodeCondition) }
     def node_condition(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::NodeConfigSource) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::NodeConfigSource).void).returns(::KubeDSL::DSL::V1::NodeConfigSource) }
     def node_config_source(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::NodeConfigStatus) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::NodeConfigStatus).void).returns(::KubeDSL::DSL::V1::NodeConfigStatus) }
     def node_config_status(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::NodeDaemonEndpoints) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::NodeDaemonEndpoints).void).returns(::KubeDSL::DSL::V1::NodeDaemonEndpoints) }
     def node_daemon_endpoints(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::NodeList) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::NodeList).void).returns(::KubeDSL::DSL::V1::NodeList) }
     def node_list(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::NodeSelector) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::NodeSelector).void).returns(::KubeDSL::DSL::V1::NodeSelector) }
     def node_selector(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::NodeSelectorRequirement) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::NodeSelectorRequirement).void).returns(::KubeDSL::DSL::V1::NodeSelectorRequirement) }
     def node_selector_requirement(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::NodeSelectorTerm) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::NodeSelectorTerm).void).returns(::KubeDSL::DSL::V1::NodeSelectorTerm) }
     def node_selector_term(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::NodeSpec) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::NodeSpec).void).returns(::KubeDSL::DSL::V1::NodeSpec) }
     def node_spec(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::NodeStatus) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::NodeStatus).void).returns(::KubeDSL::DSL::V1::NodeStatus) }
     def node_status(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::NodeSystemInfo) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::NodeSystemInfo).void).returns(::KubeDSL::DSL::V1::NodeSystemInfo) }
     def node_system_info(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ObjectFieldSelector) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ObjectFieldSelector).void).returns(::KubeDSL::DSL::V1::ObjectFieldSelector) }
     def object_field_selector(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ObjectReference) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ObjectReference).void).returns(::KubeDSL::DSL::V1::ObjectReference) }
     def object_reference(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PersistentVolume) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PersistentVolume).void).returns(::KubeDSL::DSL::V1::PersistentVolume) }
     def persistent_volume(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PersistentVolumeClaim) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PersistentVolumeClaim).void).returns(::KubeDSL::DSL::V1::PersistentVolumeClaim) }
     def persistent_volume_claim(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PersistentVolumeClaimCondition) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PersistentVolumeClaimCondition).void).returns(::KubeDSL::DSL::V1::PersistentVolumeClaimCondition) }
     def persistent_volume_claim_condition(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PersistentVolumeClaimList) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PersistentVolumeClaimList).void).returns(::KubeDSL::DSL::V1::PersistentVolumeClaimList) }
     def persistent_volume_claim_list(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PersistentVolumeClaimSpec) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PersistentVolumeClaimSpec).void).returns(::KubeDSL::DSL::V1::PersistentVolumeClaimSpec) }
     def persistent_volume_claim_spec(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PersistentVolumeClaimStatus) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PersistentVolumeClaimStatus).void).returns(::KubeDSL::DSL::V1::PersistentVolumeClaimStatus) }
     def persistent_volume_claim_status(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PersistentVolumeClaimTemplate) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PersistentVolumeClaimTemplate).void).returns(::KubeDSL::DSL::V1::PersistentVolumeClaimTemplate) }
     def persistent_volume_claim_template(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PersistentVolumeClaimVolumeSource) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PersistentVolumeClaimVolumeSource).void).returns(::KubeDSL::DSL::V1::PersistentVolumeClaimVolumeSource) }
     def persistent_volume_claim_volume_source(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PersistentVolumeList) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PersistentVolumeList).void).returns(::KubeDSL::DSL::V1::PersistentVolumeList) }
     def persistent_volume_list(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PersistentVolumeSpec) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PersistentVolumeSpec).void).returns(::KubeDSL::DSL::V1::PersistentVolumeSpec) }
     def persistent_volume_spec(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PersistentVolumeStatus) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PersistentVolumeStatus).void).returns(::KubeDSL::DSL::V1::PersistentVolumeStatus) }
     def persistent_volume_status(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PhotonPersistentDiskVolumeSource) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PhotonPersistentDiskVolumeSource).void).returns(::KubeDSL::DSL::V1::PhotonPersistentDiskVolumeSource) }
     def photon_persistent_disk_volume_source(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::Pod) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::Pod).void).returns(::KubeDSL::DSL::V1::Pod) }
     def pod(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PodAffinity) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PodAffinity).void).returns(::KubeDSL::DSL::V1::PodAffinity) }
     def pod_affinity(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PodAffinityTerm) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PodAffinityTerm).void).returns(::KubeDSL::DSL::V1::PodAffinityTerm) }
     def pod_affinity_term(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PodAntiAffinity) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PodAntiAffinity).void).returns(::KubeDSL::DSL::V1::PodAntiAffinity) }
     def pod_anti_affinity(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PodCondition) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PodCondition).void).returns(::KubeDSL::DSL::V1::PodCondition) }
     def pod_condition(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PodDNSConfig) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PodDNSConfig).void).returns(::KubeDSL::DSL::V1::PodDNSConfig) }
     def pod_dns_config(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PodDNSConfigOption) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PodDNSConfigOption).void).returns(::KubeDSL::DSL::V1::PodDNSConfigOption) }
     def pod_dns_config_option(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PodIP) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PodIP).void).returns(::KubeDSL::DSL::V1::PodIP) }
     def pod_ip(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PodList) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PodList).void).returns(::KubeDSL::DSL::V1::PodList) }
     def pod_list(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PodOS) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PodOS).void).returns(::KubeDSL::DSL::V1::PodOS) }
     def pod_os(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PodReadinessGate) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PodReadinessGate).void).returns(::KubeDSL::DSL::V1::PodReadinessGate) }
     def pod_readiness_gate(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PodSecurityContext) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PodSecurityContext).void).returns(::KubeDSL::DSL::V1::PodSecurityContext) }
     def pod_security_context(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PodSpec) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PodSpec).void).returns(::KubeDSL::DSL::V1::PodSpec) }
     def pod_spec(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PodStatus) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PodStatus).void).returns(::KubeDSL::DSL::V1::PodStatus) }
     def pod_status(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PodTemplate) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PodTemplate).void).returns(::KubeDSL::DSL::V1::PodTemplate) }
     def pod_template(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PodTemplateList) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PodTemplateList).void).returns(::KubeDSL::DSL::V1::PodTemplateList) }
     def pod_template_list(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PodTemplateSpec) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PodTemplateSpec).void).returns(::KubeDSL::DSL::V1::PodTemplateSpec) }
     def pod_template_spec(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PortStatus) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PortStatus).void).returns(::KubeDSL::DSL::V1::PortStatus) }
     def port_status(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PortworxVolumeSource) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PortworxVolumeSource).void).returns(::KubeDSL::DSL::V1::PortworxVolumeSource) }
     def portworx_volume_source(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::PreferredSchedulingTerm) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::PreferredSchedulingTerm).void).returns(::KubeDSL::DSL::V1::PreferredSchedulingTerm) }
     def preferred_scheduling_term(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::Probe) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::Probe).void).returns(::KubeDSL::DSL::V1::Probe) }
     def probe(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ProjectedVolumeSource) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ProjectedVolumeSource).void).returns(::KubeDSL::DSL::V1::ProjectedVolumeSource) }
     def projected_volume_source(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::QuobyteVolumeSource) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::QuobyteVolumeSource).void).returns(::KubeDSL::DSL::V1::QuobyteVolumeSource) }
     def quobyte_volume_source(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::RBDPersistentVolumeSource) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::RBDPersistentVolumeSource).void).returns(::KubeDSL::DSL::V1::RBDPersistentVolumeSource) }
     def rbd_persistent_volume_source(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::RBDVolumeSource) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::RBDVolumeSource).void).returns(::KubeDSL::DSL::V1::RBDVolumeSource) }
     def rbd_volume_source(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ReplicationController) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ReplicationController).void).returns(::KubeDSL::DSL::V1::ReplicationController) }
     def replication_controller(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ReplicationControllerCondition) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ReplicationControllerCondition).void).returns(::KubeDSL::DSL::V1::ReplicationControllerCondition) }
     def replication_controller_condition(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ReplicationControllerList) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ReplicationControllerList).void).returns(::KubeDSL::DSL::V1::ReplicationControllerList) }
     def replication_controller_list(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ReplicationControllerSpec) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ReplicationControllerSpec).void).returns(::KubeDSL::DSL::V1::ReplicationControllerSpec) }
     def replication_controller_spec(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ReplicationControllerStatus) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ReplicationControllerStatus).void).returns(::KubeDSL::DSL::V1::ReplicationControllerStatus) }
     def replication_controller_status(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ResourceFieldSelector) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ResourceFieldSelector).void).returns(::KubeDSL::DSL::V1::ResourceFieldSelector) }
     def resource_field_selector(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ResourceQuota) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ResourceQuota).void).returns(::KubeDSL::DSL::V1::ResourceQuota) }
     def resource_quota(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ResourceQuotaList) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ResourceQuotaList).void).returns(::KubeDSL::DSL::V1::ResourceQuotaList) }
     def resource_quota_list(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ResourceQuotaSpec) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ResourceQuotaSpec).void).returns(::KubeDSL::DSL::V1::ResourceQuotaSpec) }
     def resource_quota_spec(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ResourceQuotaStatus) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ResourceQuotaStatus).void).returns(::KubeDSL::DSL::V1::ResourceQuotaStatus) }
     def resource_quota_status(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ResourceRequirements) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ResourceRequirements).void).returns(::KubeDSL::DSL::V1::ResourceRequirements) }
     def resource_requirements(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::SELinuxOptions) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::SELinuxOptions).void).returns(::KubeDSL::DSL::V1::SELinuxOptions) }
     def se_linux_options(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ScaleIOPersistentVolumeSource) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ScaleIOPersistentVolumeSource).void).returns(::KubeDSL::DSL::V1::ScaleIOPersistentVolumeSource) }
     def scale_io_persistent_volume_source(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ScaleIOVolumeSource) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ScaleIOVolumeSource).void).returns(::KubeDSL::DSL::V1::ScaleIOVolumeSource) }
     def scale_io_volume_source(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ScopeSelector) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ScopeSelector).void).returns(::KubeDSL::DSL::V1::ScopeSelector) }
     def scope_selector(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ScopedResourceSelectorRequirement) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ScopedResourceSelectorRequirement).void).returns(::KubeDSL::DSL::V1::ScopedResourceSelectorRequirement) }
     def scoped_resource_selector_requirement(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::SeccompProfile) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::SeccompProfile).void).returns(::KubeDSL::DSL::V1::SeccompProfile) }
     def seccomp_profile(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::Secret) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::Secret).void).returns(::KubeDSL::DSL::V1::Secret) }
     def secret(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::SecretEnvSource) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::SecretEnvSource).void).returns(::KubeDSL::DSL::V1::SecretEnvSource) }
     def secret_env_source(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::SecretKeySelector) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::SecretKeySelector).void).returns(::KubeDSL::DSL::V1::SecretKeySelector) }
     def secret_key_selector(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::SecretList) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::SecretList).void).returns(::KubeDSL::DSL::V1::SecretList) }
     def secret_list(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::SecretProjection) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::SecretProjection).void).returns(::KubeDSL::DSL::V1::SecretProjection) }
     def secret_projection(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::SecretReference) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::SecretReference).void).returns(::KubeDSL::DSL::V1::SecretReference) }
     def secret_reference(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::SecretVolumeSource) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::SecretVolumeSource).void).returns(::KubeDSL::DSL::V1::SecretVolumeSource) }
     def secret_volume_source(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::SecurityContext) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::SecurityContext).void).returns(::KubeDSL::DSL::V1::SecurityContext) }
     def security_context(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::Service) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::Service).void).returns(::KubeDSL::DSL::V1::Service) }
     def service(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ServiceAccount) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ServiceAccount).void).returns(::KubeDSL::DSL::V1::ServiceAccount) }
     def service_account(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ServiceAccountList) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ServiceAccountList).void).returns(::KubeDSL::DSL::V1::ServiceAccountList) }
     def service_account_list(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ServiceAccountTokenProjection) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ServiceAccountTokenProjection).void).returns(::KubeDSL::DSL::V1::ServiceAccountTokenProjection) }
     def service_account_token_projection(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ServiceList) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ServiceList).void).returns(::KubeDSL::DSL::V1::ServiceList) }
     def service_list(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ServicePort) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ServicePort).void).returns(::KubeDSL::DSL::V1::ServicePort) }
     def service_port(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ServiceSpec) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ServiceSpec).void).returns(::KubeDSL::DSL::V1::ServiceSpec) }
     def service_spec(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::ServiceStatus) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::ServiceStatus).void).returns(::KubeDSL::DSL::V1::ServiceStatus) }
     def service_status(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::SessionAffinityConfig) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::SessionAffinityConfig).void).returns(::KubeDSL::DSL::V1::SessionAffinityConfig) }
     def session_affinity_config(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::StorageOSPersistentVolumeSource) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::StorageOSPersistentVolumeSource).void).returns(::KubeDSL::DSL::V1::StorageOSPersistentVolumeSource) }
     def storage_os_persistent_volume_source(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::StorageOSVolumeSource) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::StorageOSVolumeSource).void).returns(::KubeDSL::DSL::V1::StorageOSVolumeSource) }
     def storage_os_volume_source(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::Sysctl) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::Sysctl).void).returns(::KubeDSL::DSL::V1::Sysctl) }
     def sysctl(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::TCPSocketAction) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::TCPSocketAction).void).returns(::KubeDSL::DSL::V1::TCPSocketAction) }
     def tcp_socket_action(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::Taint) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::Taint).void).returns(::KubeDSL::DSL::V1::Taint) }
     def taint(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::Toleration) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::Toleration).void).returns(::KubeDSL::DSL::V1::Toleration) }
     def toleration(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::TopologySelectorLabelRequirement) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::TopologySelectorLabelRequirement).void).returns(::KubeDSL::DSL::V1::TopologySelectorLabelRequirement) }
     def topology_selector_label_requirement(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::TopologySelectorTerm) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::TopologySelectorTerm).void).returns(::KubeDSL::DSL::V1::TopologySelectorTerm) }
     def topology_selector_term(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::TopologySpreadConstraint) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::TopologySpreadConstraint).void).returns(::KubeDSL::DSL::V1::TopologySpreadConstraint) }
     def topology_spread_constraint(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::TypedLocalObjectReference) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::TypedLocalObjectReference).void).returns(::KubeDSL::DSL::V1::TypedLocalObjectReference) }
     def typed_local_object_reference(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::Volume) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::Volume).void).returns(::KubeDSL::DSL::V1::Volume) }
     def volume(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::VolumeDevice) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::VolumeDevice).void).returns(::KubeDSL::DSL::V1::VolumeDevice) }
     def volume_device(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::VolumeMount) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::VolumeMount).void).returns(::KubeDSL::DSL::V1::VolumeMount) }
     def volume_mount(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::VolumeNodeAffinity) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::VolumeNodeAffinity).void).returns(::KubeDSL::DSL::V1::VolumeNodeAffinity) }
     def volume_node_affinity(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::VolumeProjection) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::VolumeProjection).void).returns(::KubeDSL::DSL::V1::VolumeProjection) }
     def volume_projection(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::VsphereVirtualDiskVolumeSource) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::VsphereVirtualDiskVolumeSource).void).returns(::KubeDSL::DSL::V1::VsphereVirtualDiskVolumeSource) }
     def vsphere_virtual_disk_volume_source(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::WeightedPodAffinityTerm) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::WeightedPodAffinityTerm).void).returns(::KubeDSL::DSL::V1::WeightedPodAffinityTerm) }
     def weighted_pod_affinity_term(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::V1::WindowsSecurityContextOptions) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::V1::WindowsSecurityContextOptions).void).returns(::KubeDSL::DSL::V1::WindowsSecurityContextOptions) }
     def windows_security_context_options(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Discovery::V1::Endpoint) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Discovery::V1::Endpoint).void).returns(::KubeDSL::DSL::Discovery::V1::Endpoint) }
     def endpoint(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Discovery::V1::EndpointConditions) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Discovery::V1::EndpointConditions).void).returns(::KubeDSL::DSL::Discovery::V1::EndpointConditions) }
     def endpoint_conditions(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Discovery::V1::EndpointHints) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Discovery::V1::EndpointHints).void).returns(::KubeDSL::DSL::Discovery::V1::EndpointHints) }
     def endpoint_hints(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Discovery::V1::EndpointPort) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Discovery::V1::EndpointPort).void).returns(::KubeDSL::DSL::Discovery::V1::EndpointPort) }
     def discovery_v1_endpoint_port(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Discovery::V1::EndpointSlice) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Discovery::V1::EndpointSlice).void).returns(::KubeDSL::DSL::Discovery::V1::EndpointSlice) }
     def endpoint_slice(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Discovery::V1::EndpointSliceList) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Discovery::V1::EndpointSliceList).void).returns(::KubeDSL::DSL::Discovery::V1::EndpointSliceList) }
     def endpoint_slice_list(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Discovery::V1::ForZone) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Discovery::V1::ForZone).void).returns(::KubeDSL::DSL::Discovery::V1::ForZone) }
     def for_zone(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Events::V1::Event) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Events::V1::Event).void).returns(::KubeDSL::DSL::Events::V1::Event) }
     def events_v1_event(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Events::V1::EventList) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Events::V1::EventList).void).returns(::KubeDSL::DSL::Events::V1::EventList) }
     def events_v1_event_list(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Events::V1::EventSeries) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Events::V1::EventSeries).void).returns(::KubeDSL::DSL::Events::V1::EventSeries) }
     def events_v1_event_series(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Networking::V1::HTTPIngressPath) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Networking::V1::HTTPIngressPath).void).returns(::KubeDSL::DSL::Networking::V1::HTTPIngressPath) }
     def http_ingress_path(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Networking::V1::HTTPIngressRuleValue) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Networking::V1::HTTPIngressRuleValue).void).returns(::KubeDSL::DSL::Networking::V1::HTTPIngressRuleValue) }
     def http_ingress_rule_value(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Networking::V1::IPBlock) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Networking::V1::IPBlock).void).returns(::KubeDSL::DSL::Networking::V1::IPBlock) }
     def ip_block(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Networking::V1::Ingress) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Networking::V1::Ingress).void).returns(::KubeDSL::DSL::Networking::V1::Ingress) }
     def ingress(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Networking::V1::IngressBackend) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Networking::V1::IngressBackend).void).returns(::KubeDSL::DSL::Networking::V1::IngressBackend) }
     def ingress_backend(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Networking::V1::IngressClass) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Networking::V1::IngressClass).void).returns(::KubeDSL::DSL::Networking::V1::IngressClass) }
     def ingress_class(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Networking::V1::IngressClassList) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Networking::V1::IngressClassList).void).returns(::KubeDSL::DSL::Networking::V1::IngressClassList) }
     def ingress_class_list(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Networking::V1::IngressClassParametersReference) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Networking::V1::IngressClassParametersReference).void).returns(::KubeDSL::DSL::Networking::V1::IngressClassParametersReference) }
     def ingress_class_parameters_reference(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Networking::V1::IngressClassSpec) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Networking::V1::IngressClassSpec).void).returns(::KubeDSL::DSL::Networking::V1::IngressClassSpec) }
     def ingress_class_spec(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Networking::V1::IngressList) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Networking::V1::IngressList).void).returns(::KubeDSL::DSL::Networking::V1::IngressList) }
     def ingress_list(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Networking::V1::IngressRule) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Networking::V1::IngressRule).void).returns(::KubeDSL::DSL::Networking::V1::IngressRule) }
     def ingress_rule(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Networking::V1::IngressServiceBackend) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Networking::V1::IngressServiceBackend).void).returns(::KubeDSL::DSL::Networking::V1::IngressServiceBackend) }
     def ingress_service_backend(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Networking::V1::IngressSpec) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Networking::V1::IngressSpec).void).returns(::KubeDSL::DSL::Networking::V1::IngressSpec) }
     def ingress_spec(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Networking::V1::IngressStatus) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Networking::V1::IngressStatus).void).returns(::KubeDSL::DSL::Networking::V1::IngressStatus) }
     def ingress_status(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Networking::V1::IngressTLS) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Networking::V1::IngressTLS).void).returns(::KubeDSL::DSL::Networking::V1::IngressTLS) }
     def ingress_tls(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Networking::V1::NetworkPolicy) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Networking::V1::NetworkPolicy).void).returns(::KubeDSL::DSL::Networking::V1::NetworkPolicy) }
     def network_policy(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Networking::V1::NetworkPolicyEgressRule) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Networking::V1::NetworkPolicyEgressRule).void).returns(::KubeDSL::DSL::Networking::V1::NetworkPolicyEgressRule) }
     def network_policy_egress_rule(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Networking::V1::NetworkPolicyIngressRule) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Networking::V1::NetworkPolicyIngressRule).void).returns(::KubeDSL::DSL::Networking::V1::NetworkPolicyIngressRule) }
     def network_policy_ingress_rule(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Networking::V1::NetworkPolicyList) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Networking::V1::NetworkPolicyList).void).returns(::KubeDSL::DSL::Networking::V1::NetworkPolicyList) }
     def network_policy_list(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Networking::V1::NetworkPolicyPeer) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Networking::V1::NetworkPolicyPeer).void).returns(::KubeDSL::DSL::Networking::V1::NetworkPolicyPeer) }
     def network_policy_peer(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Networking::V1::NetworkPolicyPort) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Networking::V1::NetworkPolicyPort).void).returns(::KubeDSL::DSL::Networking::V1::NetworkPolicyPort) }
     def network_policy_port(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Networking::V1::NetworkPolicySpec) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Networking::V1::NetworkPolicySpec).void).returns(::KubeDSL::DSL::Networking::V1::NetworkPolicySpec) }
     def network_policy_spec(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Networking::V1::ServiceBackendPort) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Networking::V1::ServiceBackendPort).void).returns(::KubeDSL::DSL::Networking::V1::ServiceBackendPort) }
     def service_backend_port(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Node::V1::Overhead) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Node::V1::Overhead).void).returns(::KubeDSL::DSL::Node::V1::Overhead) }
     def overhead(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Node::V1::RuntimeClass) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Node::V1::RuntimeClass).void).returns(::KubeDSL::DSL::Node::V1::RuntimeClass) }
     def runtime_class(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Node::V1::RuntimeClassList) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Node::V1::RuntimeClassList).void).returns(::KubeDSL::DSL::Node::V1::RuntimeClassList) }
     def runtime_class_list(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Node::V1::Scheduling) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Node::V1::Scheduling).void).returns(::KubeDSL::DSL::Node::V1::Scheduling) }
     def scheduling(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Policy::V1::Eviction) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Policy::V1::Eviction).void).returns(::KubeDSL::DSL::Policy::V1::Eviction) }
     def eviction(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Policy::V1::PodDisruptionBudget) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Policy::V1::PodDisruptionBudget).void).returns(::KubeDSL::DSL::Policy::V1::PodDisruptionBudget) }
     def pod_disruption_budget(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Policy::V1::PodDisruptionBudgetList) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Policy::V1::PodDisruptionBudgetList).void).returns(::KubeDSL::DSL::Policy::V1::PodDisruptionBudgetList) }
     def pod_disruption_budget_list(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Policy::V1::PodDisruptionBudgetSpec) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Policy::V1::PodDisruptionBudgetSpec).void).returns(::KubeDSL::DSL::Policy::V1::PodDisruptionBudgetSpec) }
     def pod_disruption_budget_spec(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Policy::V1::PodDisruptionBudgetStatus) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Policy::V1::PodDisruptionBudgetStatus).void).returns(::KubeDSL::DSL::Policy::V1::PodDisruptionBudgetStatus) }
     def pod_disruption_budget_status(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Rbac::V1::AggregationRule) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Rbac::V1::AggregationRule).void).returns(::KubeDSL::DSL::Rbac::V1::AggregationRule) }
     def aggregation_rule(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Rbac::V1::ClusterRole) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Rbac::V1::ClusterRole).void).returns(::KubeDSL::DSL::Rbac::V1::ClusterRole) }
     def cluster_role(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Rbac::V1::ClusterRoleBinding) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Rbac::V1::ClusterRoleBinding).void).returns(::KubeDSL::DSL::Rbac::V1::ClusterRoleBinding) }
     def cluster_role_binding(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Rbac::V1::ClusterRoleBindingList) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Rbac::V1::ClusterRoleBindingList).void).returns(::KubeDSL::DSL::Rbac::V1::ClusterRoleBindingList) }
     def cluster_role_binding_list(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Rbac::V1::ClusterRoleList) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Rbac::V1::ClusterRoleList).void).returns(::KubeDSL::DSL::Rbac::V1::ClusterRoleList) }
     def cluster_role_list(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Rbac::V1::PolicyRule) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Rbac::V1::PolicyRule).void).returns(::KubeDSL::DSL::Rbac::V1::PolicyRule) }
     def policy_rule(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Rbac::V1::Role) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Rbac::V1::Role).void).returns(::KubeDSL::DSL::Rbac::V1::Role) }
     def role(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Rbac::V1::RoleBinding) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Rbac::V1::RoleBinding).void).returns(::KubeDSL::DSL::Rbac::V1::RoleBinding) }
     def role_binding(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Rbac::V1::RoleBindingList) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Rbac::V1::RoleBindingList).void).returns(::KubeDSL::DSL::Rbac::V1::RoleBindingList) }
     def role_binding_list(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Rbac::V1::RoleList) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Rbac::V1::RoleList).void).returns(::KubeDSL::DSL::Rbac::V1::RoleList) }
     def role_list(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Rbac::V1::RoleRef) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Rbac::V1::RoleRef).void).returns(::KubeDSL::DSL::Rbac::V1::RoleRef) }
     def role_ref(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Rbac::V1::Subject) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Rbac::V1::Subject).void).returns(::KubeDSL::DSL::Rbac::V1::Subject) }
     def subject(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Scheduling::V1::PriorityClass) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Scheduling::V1::PriorityClass).void).returns(::KubeDSL::DSL::Scheduling::V1::PriorityClass) }
     def priority_class(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Scheduling::V1::PriorityClassList) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Scheduling::V1::PriorityClassList).void).returns(::KubeDSL::DSL::Scheduling::V1::PriorityClassList) }
     def priority_class_list(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Storage::V1::CSIDriver) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Storage::V1::CSIDriver).void).returns(::KubeDSL::DSL::Storage::V1::CSIDriver) }
     def csi_driver(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Storage::V1::CSIDriverList) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Storage::V1::CSIDriverList).void).returns(::KubeDSL::DSL::Storage::V1::CSIDriverList) }
     def csi_driver_list(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Storage::V1::CSIDriverSpec) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Storage::V1::CSIDriverSpec).void).returns(::KubeDSL::DSL::Storage::V1::CSIDriverSpec) }
     def csi_driver_spec(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Storage::V1::CSINode) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Storage::V1::CSINode).void).returns(::KubeDSL::DSL::Storage::V1::CSINode) }
     def csi_node(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Storage::V1::CSINodeDriver) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Storage::V1::CSINodeDriver).void).returns(::KubeDSL::DSL::Storage::V1::CSINodeDriver) }
     def csi_node_driver(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Storage::V1::CSINodeList) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Storage::V1::CSINodeList).void).returns(::KubeDSL::DSL::Storage::V1::CSINodeList) }
     def csi_node_list(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Storage::V1::CSINodeSpec) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Storage::V1::CSINodeSpec).void).returns(::KubeDSL::DSL::Storage::V1::CSINodeSpec) }
     def csi_node_spec(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Storage::V1::StorageClass) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Storage::V1::StorageClass).void).returns(::KubeDSL::DSL::Storage::V1::StorageClass) }
     def storage_class(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Storage::V1::StorageClassList) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Storage::V1::StorageClassList).void).returns(::KubeDSL::DSL::Storage::V1::StorageClassList) }
     def storage_class_list(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Storage::V1::TokenRequest) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Storage::V1::TokenRequest).void).returns(::KubeDSL::DSL::Storage::V1::TokenRequest) }
     def storage_v1_token_request(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Storage::V1::VolumeAttachment) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Storage::V1::VolumeAttachment).void).returns(::KubeDSL::DSL::Storage::V1::VolumeAttachment) }
     def volume_attachment(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Storage::V1::VolumeAttachmentList) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Storage::V1::VolumeAttachmentList).void).returns(::KubeDSL::DSL::Storage::V1::VolumeAttachmentList) }
     def volume_attachment_list(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Storage::V1::VolumeAttachmentSource) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Storage::V1::VolumeAttachmentSource).void).returns(::KubeDSL::DSL::Storage::V1::VolumeAttachmentSource) }
     def volume_attachment_source(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Storage::V1::VolumeAttachmentSpec) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Storage::V1::VolumeAttachmentSpec).void).returns(::KubeDSL::DSL::Storage::V1::VolumeAttachmentSpec) }
     def volume_attachment_spec(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Storage::V1::VolumeAttachmentStatus) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Storage::V1::VolumeAttachmentStatus).void).returns(::KubeDSL::DSL::Storage::V1::VolumeAttachmentStatus) }
     def volume_attachment_status(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Storage::V1::VolumeError) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Storage::V1::VolumeError).void).returns(::KubeDSL::DSL::Storage::V1::VolumeError) }
     def volume_error(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Storage::V1::VolumeNodeResources) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Storage::V1::VolumeNodeResources).void).returns(::KubeDSL::DSL::Storage::V1::VolumeNodeResources) }
     def volume_node_resources(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apiextensions::V1::CustomResourceColumnDefinition) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Apiextensions::V1::CustomResourceColumnDefinition).void).returns(::KubeDSL::DSL::Apiextensions::V1::CustomResourceColumnDefinition) }
     def custom_resource_column_definition(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apiextensions::V1::CustomResourceConversion) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Apiextensions::V1::CustomResourceConversion).void).returns(::KubeDSL::DSL::Apiextensions::V1::CustomResourceConversion) }
     def custom_resource_conversion(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinition) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinition).void).returns(::KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinition) }
     def custom_resource_definition(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionCondition) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionCondition).void).returns(::KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionCondition) }
     def custom_resource_definition_condition(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionList) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionList).void).returns(::KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionList) }
     def custom_resource_definition_list(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionNames) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionNames).void).returns(::KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionNames) }
     def custom_resource_definition_names(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionSpec) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionSpec).void).returns(::KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionSpec) }
     def custom_resource_definition_spec(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionStatus) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionStatus).void).returns(::KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionStatus) }
     def custom_resource_definition_status(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionVersion) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionVersion).void).returns(::KubeDSL::DSL::Apiextensions::V1::CustomResourceDefinitionVersion) }
     def custom_resource_definition_version(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apiextensions::V1::CustomResourceSubresourceScale) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Apiextensions::V1::CustomResourceSubresourceScale).void).returns(::KubeDSL::DSL::Apiextensions::V1::CustomResourceSubresourceScale) }
     def custom_resource_subresource_scale(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apiextensions::V1::CustomResourceSubresources) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Apiextensions::V1::CustomResourceSubresources).void).returns(::KubeDSL::DSL::Apiextensions::V1::CustomResourceSubresources) }
     def custom_resource_subresources(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apiextensions::V1::CustomResourceValidation) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Apiextensions::V1::CustomResourceValidation).void).returns(::KubeDSL::DSL::Apiextensions::V1::CustomResourceValidation) }
     def custom_resource_validation(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apiextensions::V1::ExternalDocumentation) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Apiextensions::V1::ExternalDocumentation).void).returns(::KubeDSL::DSL::Apiextensions::V1::ExternalDocumentation) }
     def external_documentation(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apiextensions::V1::JSONSchemaProps) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Apiextensions::V1::JSONSchemaProps).void).returns(::KubeDSL::DSL::Apiextensions::V1::JSONSchemaProps) }
     def json_schema_props(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apiextensions::V1::ServiceReference) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Apiextensions::V1::ServiceReference).void).returns(::KubeDSL::DSL::Apiextensions::V1::ServiceReference) }
     def apiextensions_v1_service_reference(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apiextensions::V1::ValidationRule) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Apiextensions::V1::ValidationRule).void).returns(::KubeDSL::DSL::Apiextensions::V1::ValidationRule) }
     def validation_rule(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apiextensions::V1::WebhookClientConfig) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Apiextensions::V1::WebhookClientConfig).void).returns(::KubeDSL::DSL::Apiextensions::V1::WebhookClientConfig) }
     def apiextensions_v1_webhook_client_config(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apiextensions::V1::WebhookConversion) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Apiextensions::V1::WebhookConversion).void).returns(::KubeDSL::DSL::Apiextensions::V1::WebhookConversion) }
     def webhook_conversion(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Meta::V1::APIGroup) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Meta::V1::APIGroup).void).returns(::KubeDSL::DSL::Meta::V1::APIGroup) }
     def api_group(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Meta::V1::APIGroupList) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Meta::V1::APIGroupList).void).returns(::KubeDSL::DSL::Meta::V1::APIGroupList) }
     def api_group_list(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Meta::V1::APIResource) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Meta::V1::APIResource).void).returns(::KubeDSL::DSL::Meta::V1::APIResource) }
     def api_resource(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Meta::V1::APIResourceList) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Meta::V1::APIResourceList).void).returns(::KubeDSL::DSL::Meta::V1::APIResourceList) }
     def api_resource_list(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Meta::V1::APIVersions) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Meta::V1::APIVersions).void).returns(::KubeDSL::DSL::Meta::V1::APIVersions) }
     def api_versions(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Meta::V1::Condition) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Meta::V1::Condition).void).returns(::KubeDSL::DSL::Meta::V1::Condition) }
     def condition(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Meta::V1::DeleteOptions) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Meta::V1::DeleteOptions).void).returns(::KubeDSL::DSL::Meta::V1::DeleteOptions) }
     def delete_options(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Meta::V1::GroupVersionForDiscovery) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Meta::V1::GroupVersionForDiscovery).void).returns(::KubeDSL::DSL::Meta::V1::GroupVersionForDiscovery) }
     def group_version_for_discovery(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Meta::V1::LabelSelector) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Meta::V1::LabelSelector).void).returns(::KubeDSL::DSL::Meta::V1::LabelSelector) }
     def label_selector(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Meta::V1::LabelSelectorRequirement) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Meta::V1::LabelSelectorRequirement).void).returns(::KubeDSL::DSL::Meta::V1::LabelSelectorRequirement) }
     def label_selector_requirement(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Meta::V1::ListMeta) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Meta::V1::ListMeta).void).returns(::KubeDSL::DSL::Meta::V1::ListMeta) }
     def list_meta(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Meta::V1::ManagedFieldsEntry) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Meta::V1::ManagedFieldsEntry).void).returns(::KubeDSL::DSL::Meta::V1::ManagedFieldsEntry) }
     def managed_fields_entry(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Meta::V1::ObjectMeta) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Meta::V1::ObjectMeta).void).returns(::KubeDSL::DSL::Meta::V1::ObjectMeta) }
     def object_meta(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Meta::V1::OwnerReference) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Meta::V1::OwnerReference).void).returns(::KubeDSL::DSL::Meta::V1::OwnerReference) }
     def owner_reference(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Meta::V1::Preconditions) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Meta::V1::Preconditions).void).returns(::KubeDSL::DSL::Meta::V1::Preconditions) }
     def preconditions(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Meta::V1::ServerAddressByClientCIDR) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Meta::V1::ServerAddressByClientCIDR).void).returns(::KubeDSL::DSL::Meta::V1::ServerAddressByClientCIDR) }
     def server_address_by_client_cidr(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Meta::V1::Status) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Meta::V1::Status).void).returns(::KubeDSL::DSL::Meta::V1::Status) }
     def status(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Meta::V1::StatusCause) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Meta::V1::StatusCause).void).returns(::KubeDSL::DSL::Meta::V1::StatusCause) }
     def status_cause(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Meta::V1::StatusDetails) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Meta::V1::StatusDetails).void).returns(::KubeDSL::DSL::Meta::V1::StatusDetails) }
     def status_details(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Meta::V1::WatchEvent) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Meta::V1::WatchEvent).void).returns(::KubeDSL::DSL::Meta::V1::WatchEvent) }
     def watch_event(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Pkg::Version::Info) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Pkg::Version::Info).void).returns(::KubeDSL::DSL::Pkg::Version::Info) }
     def info(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apiregistration::V1::APIService) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Apiregistration::V1::APIService).void).returns(::KubeDSL::DSL::Apiregistration::V1::APIService) }
     def api_service(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apiregistration::V1::APIServiceCondition) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Apiregistration::V1::APIServiceCondition).void).returns(::KubeDSL::DSL::Apiregistration::V1::APIServiceCondition) }
     def api_service_condition(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apiregistration::V1::APIServiceList) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Apiregistration::V1::APIServiceList).void).returns(::KubeDSL::DSL::Apiregistration::V1::APIServiceList) }
     def api_service_list(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apiregistration::V1::APIServiceSpec) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Apiregistration::V1::APIServiceSpec).void).returns(::KubeDSL::DSL::Apiregistration::V1::APIServiceSpec) }
     def api_service_spec(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apiregistration::V1::APIServiceStatus) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Apiregistration::V1::APIServiceStatus).void).returns(::KubeDSL::DSL::Apiregistration::V1::APIServiceStatus) }
     def api_service_status(&block); end
 
-    T::Sig::WithoutRuntime.sig { params(block: T.proc.void).returns(::KubeDSL::DSL::Apiregistration::V1::ServiceReference) }
+    T::Sig::WithoutRuntime.sig { params(block: T.proc.bind(::KubeDSL::DSL::Apiregistration::V1::ServiceReference).void).returns(::KubeDSL::DSL::Apiregistration::V1::ServiceReference) }
     def apiregistration_v1_service_reference(&block); end
   end
 end


### PR DESCRIPTION
The example in the README didn't work out of the box with Sorbet typechecking:

```rb
ns = KubeDSL.namespace do
  metadata do
    name 'my-namespace'
  end
end
```

```console
Method metadata does not exist on T.class_of(<root>)
```

Additionally the type for the `metadata` method previously didn't actually even accept a block.

This PR should fix both of those things.