### PR TITLE
Bump dry inflector to 1.2.0

### DIFF
--- a/kube-dsl.gemspec
+++ b/kube-dsl.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
 
   s.description = s.summary = 'A Ruby DSL for defining Kubernetes resources.'
 
-  s.add_dependency 'dry-inflector', '~> 0.2'
+  s.add_dependency 'dry-inflector', '~> 1.2.0'
 
   s.require_path = 'lib'
   s.files = Dir['{lib,spec,rbi}/**/*', 'Gemfile', 'LICENSE', 'CHANGELOG.md', 'README.md', 'Rakefile', 'kube-dsl.gemspec']


### PR DESCRIPTION
Resolves issue with dependency on dry-inflector being a major version behind. Would cause issues when a project used dry-effects gem which has a minimum acceptable version of 0.4