### PR TITLE
Allow dry-inflector 1.x

### DIFF
--- a/kube-dsl.gemspec
+++ b/kube-dsl.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
 
   s.description = s.summary = 'A Ruby DSL for defining Kubernetes resources.'
 
-  s.add_dependency 'dry-inflector', '~> 0.2'
+  s.add_dependency 'dry-inflector', '>= 0.2.1', '< 2'
 
   s.require_path = 'lib'
   s.files = Dir['{lib,spec,rbi}/**/*', 'Gemfile', 'LICENSE', 'CHANGELOG.md', 'README.md', 'Rakefile', 'kube-dsl.gemspec']


### PR DESCRIPTION
Since 1.x contains no breaking changes and was largely an arbitrary bump.